### PR TITLE
Profile backend

### DIFF
--- a/db/profile/GetActivePatientPlans.sql
+++ b/db/profile/GetActivePatientPlans.sql
@@ -1,0 +1,28 @@
+-- Active plans with per-plan completion % for a patient
+SELECT
+    p.plan_id,
+    p.goal,
+    s.visit_type AS category,
+    p.start_date,
+    p.end_date,
+    ROUND(
+        COALESCE(
+            (SELECT SUM(ec.num_exe_completed)
+             FROM exercise_completion ec
+             WHERE ec.plan_id = p.plan_id
+               AND ec.session_id = p.session_id),
+            0
+        ) / NULLIF(
+            (SELECT SUM(pe.reps * pe.num_sets * pe.time_duration *
+                        (CASE pe.time_unit WHEN 'Weekly' THEN 1 ELSE 7 END))
+             FROM plan_exercises pe
+             WHERE pe.plan_id = p.plan_id
+               AND pe.session_id = p.session_id)
+            * NULLIF(TIMESTAMPDIFF(WEEK, p.start_date, p.end_date), 0),
+            0
+        ) * 100,
+    1) AS completion_percent
+FROM plans p
+JOIN sessions s ON p.session_id = s.session_id
+WHERE s.patient_id = ?
+  AND s.session_status = 'ACTIVE';

--- a/db/profile/GetProfileInfo.sql
+++ b/db/profile/GetProfileInfo.sql
@@ -1,0 +1,10 @@
+-- Profile info for any user role
+SELECT
+    first_name,
+    last_name,
+    email,
+    phone,
+    birth_date,
+    license_number
+FROM registered_users
+WHERE user_id = ?;

--- a/server/app/api/profile_routes.py
+++ b/server/app/api/profile_routes.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends
+
+from app.dal.profile_repository import ProfileRepository
+from app.db.session import get_db
+from app.models.profile.profile import ActivePlan, ProfileData
+from app.services.profile_services import ProfileServices
+
+profile_router = APIRouter()
+
+
+@profile_router.get("/{user_id}", tags=["Profile"], response_model=ProfileData)
+async def get_profile(user_id: str, db=Depends(get_db)):
+    profile_repository = ProfileRepository(db=db)
+    profile_service = ProfileServices(repository=profile_repository)
+    return await profile_service.get_profile_data(user_id)
+
+
+@profile_router.get("/{user_id}/plans", tags=["Profile"], response_model=list[ActivePlan])
+async def get_patient_plans(user_id: str, db=Depends(get_db)):
+    profile_repository = ProfileRepository(db=db)
+    profile_service = ProfileServices(repository=profile_repository)
+    return await profile_service.get_active_patient_plans(user_id)

--- a/server/app/dal/profile_repository.py
+++ b/server/app/dal/profile_repository.py
@@ -1,0 +1,76 @@
+from aiomysql import DictCursor
+
+from app.models.profile.profile import ActivePlan, ProfileData
+
+
+class ProfileRepository:
+    def __init__(self, db: DictCursor) -> None:
+        self.cursor = db
+
+    async def get_profile_data(self, user_id: str) -> ProfileData | None:
+        """Fetches personal profile info for any user role.
+
+        Args:
+            user_id: The user's ID.
+
+        Returns:
+            A ProfileData instance, or None if not found.
+        """
+        await self.cursor.execute(
+            query="""
+                SELECT last_name,
+                       email,
+                       phone,
+                       birth_date,
+                       license_number
+                FROM registered_users
+                WHERE user_id = %s
+            """,
+            args=(user_id,),
+        )
+        row = await self.cursor.fetchone()
+        return ProfileData.model_validate(row) if row else None
+
+    async def get_active_patient_plans(self, user_id: str) -> list[ActivePlan]:
+        """Fetches active plans with per-plan completion % for a patient.
+
+        Args:
+            user_id: The patient's user ID.
+
+        Returns:
+            A list of ActivePlan instances.
+        """
+        await self.cursor.execute(
+            query="""
+                SELECT
+                    p.plan_id,
+                    p.goal,
+                    s.visit_type AS category,
+                    p.start_date,
+                    p.end_date,
+                    ROUND(
+                        COALESCE(
+                            (SELECT SUM(ec.num_exe_completed)
+                             FROM exercise_completion ec
+                             WHERE ec.plan_id = p.plan_id
+                               AND ec.session_id = p.session_id),
+                            0
+                        ) / NULLIF(
+                            (SELECT SUM(pe.reps * pe.num_sets * pe.time_duration *
+                                        (CASE pe.time_unit WHEN 'Weekly' THEN 1 ELSE 7 END))
+                             FROM plan_exercises pe
+                             WHERE pe.plan_id = p.plan_id
+                               AND pe.session_id = p.session_id)
+                            * NULLIF(TIMESTAMPDIFF(WEEK, p.start_date, p.end_date), 0),
+                            0
+                        ) * 100,
+                    1) AS completion_percent
+                FROM plans p
+                JOIN sessions s ON p.session_id = s.session_id
+                WHERE s.patient_id = %s
+                  AND s.session_status = 'ACTIVE'
+            """,
+            args=(user_id,),
+        )
+        rows = await self.cursor.fetchall()
+        return [ActivePlan.model_validate(row) for row in rows]

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -5,6 +5,7 @@ from app.api.health import health_router
 from app.api.user_routes import user_router
 from app.core.config import settings
 from app.api.patient_routes import patient_router
+from app.api.profile_routes import profile_router
 
 def get_application() -> FastAPI:
     _app = FastAPI(
@@ -23,6 +24,7 @@ def get_application() -> FastAPI:
     _app.include_router(health_router)
     _app.include_router(user_router, prefix="/users")
     _app.include_router(patient_router, prefix="/patient")
+    _app.include_router(profile_router, prefix="/profile")
 
     return _app
 

--- a/server/app/models/profile/profile.py
+++ b/server/app/models/profile/profile.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+
+
+class ProfileData(BaseModel):
+    """Personal info returned for any user role."""
+
+    last_name: str
+    email: str
+    phone: str
+    birth_date: str
+    license_number: str | None = None
+
+
+class ActivePlan(BaseModel):
+    """One active plan with its overall completion percentage."""
+
+    plan_id: int
+    goal: str
+    category: str
+    start_date: str
+    end_date: str
+    completion_percent: float | None = None

--- a/server/app/services/profile_services.py
+++ b/server/app/services/profile_services.py
@@ -1,0 +1,40 @@
+from fastapi import HTTPException, status
+
+from app.dal.profile_repository import ProfileRepository
+from app.models.profile.profile import ActivePlan, ProfileData
+
+
+class ProfileServices:
+    def __init__(self, repository: ProfileRepository) -> None:
+        self.repository = repository
+
+    async def get_profile_data(self, user_id: str) -> ProfileData:
+        """Returns personal info for the given user.
+
+        Args:
+            user_id: The user's ID.
+
+        Returns:
+            ProfileData for the user.
+
+        Raises:
+            HTTPException: 404 if the user is not found.
+        """
+        profile = await self.repository.get_profile_data(user_id)
+        if not profile:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User not found",
+            )
+        return profile
+
+    async def get_active_patient_plans(self, user_id: str) -> list[ActivePlan]:
+        """Returns active plans with completion % for a patient.
+
+        Args:
+            user_id: The patient's user ID.
+
+        Returns:
+            List of ActivePlan instances.
+        """
+        return await self.repository.get_active_patient_plans(user_id)


### PR DESCRIPTION
-Created db/profile/ with two SQL reference files (GetProfileInfo.sql, GetActivePatientPlans.sql)
-Added models/profile/profile.py — ProfileData and ActivePlan Pydantic models
-Added dal/profile_repository.py — raw SQL queries for user info and per-plan completion %
-Added services/profile_services.py — business logic with 404 handling
-Added api/profile_routes.py — two endpoints registered at /profile:
-GET /profile/{user_id} → personal info
-GET /profile/{user_id}/plans → active plans with completion %
