### PR TITLE
feat: implement treatment plan creation linked to visit summary

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import CreateTreatmentPlan from './pages/create-treatment-plan/CreateTreatmentPl
 import ViewTreatmentPlan from './pages/view-treatment-plan/ViewTreatmentPlan'
 import ProfilePage from './pages/profile/ProfilePage'
 import ExerciseSchedule from './pages/patient/schedule-exercise/ExerciseSchedule'
+import DevLogin from './pages/dev/DevLogin' // DEV ONLY — remove before production
 
 
 function AnimatedRoutes() {
@@ -45,6 +46,7 @@ function AnimatedRoutes() {
       <Route path="/patient/:id/treatment-plans/:planId" element={<PageTransition><ViewTreatmentPlan /></PageTransition>} />
       <Route path="/patient/:id/treatment-plans" element={<PageTransition><ViewTreatmentPlan /></PageTransition>} />
       <Route path="/profile" element={<PageTransition><ProfilePage /></PageTransition>} />
+      <Route path="/dev-login" element={<DevLogin />} />{/* DEV ONLY */}
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/client/src/hooks/useCreatePlan.ts
+++ b/client/src/hooks/useCreatePlan.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query'
+
+import apiClient from '@/lib/apiClient'
+
+export interface CreatePlanPayload {
+  session_id: number
+  goal: string
+  start_date: string
+  end_date: string
+}
+
+export interface CreatePlanResponse {
+  plan_id: number
+  session_id: number
+}
+
+export function useCreatePlan() {
+  return useMutation({
+    mutationFn: async (payload: CreatePlanPayload) => {
+      const res = await apiClient.post<CreatePlanResponse>('/visit-summary/plan', payload)
+      return res.data
+    },
+  })
+}

--- a/client/src/hooks/useCreateVisitSummary.ts
+++ b/client/src/hooks/useCreateVisitSummary.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query'
+
+import apiClient from '@/lib/apiClient'
+
+export interface CreateVisitSummaryPayload {
+  visit_date: string
+  visit_time: string
+  treatment_area: string
+  medical_diagnosis: string
+  description: string
+  recommendations?: string
+  patient_id: string
+  therapist_id: string
+  therapist_role: string
+}
+
+export function useCreateVisitSummary() {
+  return useMutation({
+    mutationFn: async (payload: CreateVisitSummaryPayload) => {
+      const res = await apiClient.post<{ session_id: number }>('/visit-summary', payload)
+      return res.data
+    },
+  })
+}

--- a/client/src/hooks/useVisitSummaries.ts
+++ b/client/src/hooks/useVisitSummaries.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+
+import apiClient from '@/lib/apiClient'
+import type { SessionListItem, VisitSummaryPatientData } from '@/types'
+
+export function useVisitSummaries(patientId: string | undefined) {
+  return useQuery<SessionListItem[]>({
+    queryKey: ['visitSummaries', patientId],
+    queryFn: async () => {
+      const res = await apiClient.get<SessionListItem[]>(`/visit-summary/sessions/${patientId}`)
+      return res.data
+    },
+    enabled: !!patientId,
+  })
+}
+
+export function useVisitSummary(patientId: string | undefined) {
+  return useQuery<VisitSummaryPatientData>({
+    queryKey: ['visitSummary', 'patient', patientId],
+    queryFn: async () => {
+      const res = await apiClient.get(`/visit-summary/patient/${patientId}`)
+      return res.data
+    },
+    enabled: !!patientId,
+  })
+}

--- a/client/src/pages/all-visit-summaries/AllVisitSummaries.tsx
+++ b/client/src/pages/all-visit-summaries/AllVisitSummaries.tsx
@@ -1,25 +1,15 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { ChevronLeft, ChevronRight, Phone, Mail } from 'lucide-react'
 import TopNav from '@/components/TopNav'
+import { useVisitSummaries } from '@/hooks/useVisitSummaries'
+import type { SessionListItem } from '@/types'
 
 import '../patient-details/PatientDetails.css'
 import './AllVisitSummaries.css'
 
 type VisitType = 'Physical Therapy' | 'Training'
 type FilterTab = 'All Sessions' | VisitType
-
-interface VisitEntry {
-  id: string
-  sessionNumber: number
-  visitDate: string
-  visitTime: string
-  visitType: VisitType
-  therapistName: string
-  treatmentArea: string
-  medicalDiagnosis?: string
-  description: string
-}
 
 const PATIENT = {
   id: '1',
@@ -30,42 +20,11 @@ const PATIENT = {
   email: 'john.smith@example.com',
 }
 
-const MOCK_VISITS: VisitEntry[] = [
-  {
-    id: 'v3',
-    sessionNumber: 3,
-    visitDate: '2025-01-10',
-    visitTime: '10:00 AM',
-    visitType: 'Physical Therapy',
-    therapistName: 'Dr. Liran Cohen',
-    treatmentArea: 'Rotator Cuff Strengthening',
-    medicalDiagnosis: 'Rotator Cuff Tear',
-    description: 'Continued resistance exercises. Pain level reduced to 2/10.',
-  },
-  {
-    id: 'v2',
-    sessionNumber: 2,
-    visitDate: '2025-01-08',
-    visitTime: '10:00 AM',
-    visitType: 'Training',
-    therapistName: 'Alex Trainer',
-    treatmentArea: 'Progress Evaluation',
-    medicalDiagnosis: 'Shoulder Impingement',
-    description: 'Mid-program assessment. Patient meets all milestones.',
-  },
-  {
-    id: 'v1',
-    sessionNumber: 1,
-    visitDate: '2025-01-06',
-    visitTime: '10:00 AM',
-    visitType: 'Physical Therapy',
-    therapistName: 'Dr. Liran Cohen',
-    treatmentArea: 'Range of Motion Exercises',
-    description: 'Good compliance with home exercises.',
-  },
-]
-
 const FILTER_TABS: FilterTab[] = ['All Sessions', 'Physical Therapy', 'Training']
+
+function apiVisitTypeToLabel(apiType: string): VisitType {
+  return apiType === 'FITNESS' ? 'Training' : 'Physical Therapy'
+}
 
 function calculateAge(birthDate: string): number {
   const today = new Date()
@@ -86,13 +45,20 @@ function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
 }
 
+function formatTime(time: string): string {
+  // time arrives as "HH:MM:SS" from backend — display as "HH:MM"
+  return time.slice(0, 5)
+}
+
 interface VisitCardProps {
-  visit: VisitEntry
+  session: SessionListItem
+  sessionNumber: number
   onClick: () => void
 }
 
-function VisitCard({ visit, onClick }: VisitCardProps) {
-  const isPhysicalTherapy = visit.visitType === 'Physical Therapy'
+function VisitCard({ session, sessionNumber, onClick }: VisitCardProps) {
+  const visitType = apiVisitTypeToLabel(session.visit_type)
+  const isPhysicalTherapy = visitType === 'Physical Therapy'
 
   return (
     <div
@@ -104,24 +70,26 @@ function VisitCard({ visit, onClick }: VisitCardProps) {
     >
       {/* Left: session number + date/time */}
       <div className="avs-visit-card__left">
-        <p className="avs-visit-card__session">Session {visit.sessionNumber}</p>
-        <p className="avs-visit-card__date">{formatDate(visit.visitDate)}</p>
-        <p className="avs-visit-card__time">{visit.visitTime}</p>
+        <p className="avs-visit-card__session">Session {sessionNumber}</p>
+        <p className="avs-visit-card__date">{formatDate(session.visit_date)}</p>
+        <p className="avs-visit-card__time">{formatTime(session.visit_time)}</p>
       </div>
 
       {/* Center: badge + therapist + treatmentArea + diagnosis + description */}
       <div className="avs-visit-card__center">
         <div className="avs-visit-card__top-row">
           <span className={`avs-visit-card__badge ${isPhysicalTherapy ? 'avs-visit-card__badge--pt' : 'avs-visit-card__badge--training'}`}>
-            {visit.visitType}
+            {visitType}
           </span>
-          <span className="avs-visit-card__therapist">{visit.therapistName}</span>
+          <span className="avs-visit-card__therapist">
+            {session.therapist_first_name} {session.therapist_last_name}
+          </span>
         </div>
-        <p className="avs-visit-card__focus">{visit.treatmentArea}</p>
-        {visit.medicalDiagnosis && (
-          <p className="avs-visit-card__diagnosis">Diagnosis: {visit.medicalDiagnosis}</p>
+        <p className="avs-visit-card__focus">{session.treatment_area}</p>
+        {session.medical_diagnosis && (
+          <p className="avs-visit-card__diagnosis">Diagnosis: {session.medical_diagnosis}</p>
         )}
-        <p className="avs-visit-card__note">{visit.description}</p>
+        <p className="avs-visit-card__note">{session.description}</p>
       </div>
 
       {/* Right: chevron */}
@@ -134,13 +102,22 @@ function VisitCard({ visit, onClick }: VisitCardProps) {
 
 export default function AllVisitSummaries() {
   const navigate = useNavigate()
+  const { id } = useParams<{ id: string }>()
   const [activeFilter, setActiveFilter] = useState<FilterTab>('All Sessions')
+
+  const { data: sessions, isLoading, isError } = useVisitSummaries(id)
+
+  console.log('[DEBUG] AllVisitSummaries GET /visit-summary/sessions response:', sessions)
 
   const age = calculateAge(PATIENT.birthDate)
 
-  const filteredVisits = activeFilter === 'All Sessions'
-    ? MOCK_VISITS
-    : MOCK_VISITS.filter((v) => v.visitType === activeFilter)
+  const filteredSessions = (sessions ?? []).filter((s) => {
+    if (activeFilter === 'All Sessions') return true
+    return apiVisitTypeToLabel(s.visit_type) === activeFilter
+  })
+
+  // Oldest session is #1, newest is #N
+  const totalCount = sessions?.length ?? 0
 
   return (
     <div className="avs-page">
@@ -166,7 +143,7 @@ export default function AllVisitSummaries() {
                 {PATIENT.firstName} {PATIENT.lastName}
               </p>
               <div className="patient-profile-card__meta-row">
-                <span>ID: #{PATIENT.id}</span>
+                <span>ID: #{id}</span>
                 <span className="patient-profile-card__sep">|</span>
                 <span>{age} years old</span>
                 <span className="patient-profile-card__sep">|</span>
@@ -200,7 +177,10 @@ export default function AllVisitSummaries() {
             <button
               type="button"
               className="avs-new-btn"
-              onClick={() => navigate(`/patient/${PATIENT.id}/visit-summaries/new`)}
+              onClick={() => {
+                console.log('[DEBUG] AllVisitSummaries navigating to new visit, id:', id)
+                navigate(`/patient/${id}/visit-summaries/new`)
+              }}
             >
               <span className="avs-new-btn__icon">+</span>
               New Summary
@@ -209,17 +189,25 @@ export default function AllVisitSummaries() {
 
           {/* ── Visit cards list ── */}
           <div className="avs-list">
-            {filteredVisits.length === 0 ? (
-              <p className="avs-empty">No sessions found for this filter.</p>
-            ) : (
-              filteredVisits.map((visit) => (
-                <VisitCard
-                  key={visit.id}
-                  visit={visit}
-                  onClick={() => navigate(`/patient/${PATIENT.id}/visit-summaries/${visit.id}`)}
-                />
-              ))
+            {isLoading && (
+              <p className="avs-empty">Loading sessions…</p>
             )}
+            {isError && (
+              <p className="avs-empty" style={{ color: 'var(--color-error, #e53e3e)' }}>
+                Failed to load sessions. Please try again.
+              </p>
+            )}
+            {!isLoading && !isError && filteredSessions.length === 0 && (
+              <p className="avs-empty">No sessions found for this filter.</p>
+            )}
+            {!isLoading && !isError && filteredSessions.map((session, index) => (
+              <VisitCard
+                key={session.session_id}
+                session={session}
+                sessionNumber={totalCount - index}
+                onClick={() => navigate(`/patient/${id}/visit-summaries/${session.session_id}`)}
+              />
+            ))}
           </div>
         </div>
       </main>

--- a/client/src/pages/create-treatment-plan/CreateTreatmentPlan.tsx
+++ b/client/src/pages/create-treatment-plan/CreateTreatmentPlan.tsx
@@ -6,6 +6,7 @@ import { authAtom } from '@/store/authAtom'
 import TopNav from '@/components/TopNav'
 import AddExerciseModal from './AddExerciseModal'
 import type { ExerciseEntry } from './AddExerciseModal'
+import { useCreatePlan } from '@/hooks/useCreatePlan'
 
 import '../patient-details/PatientDetails.css'
 import './CreateTreatmentPlan.css'
@@ -23,6 +24,7 @@ export interface PlanFormState {
 interface LocationState {
   medical_diagnosis?: string
   patient_id?: string
+  session_id?: number
   plan_data?: PlanFormState
 }
 
@@ -41,6 +43,7 @@ export default function CreateTreatmentPlan() {
   const state = (location.state ?? {}) as Partial<LocationState>
   const medicalDiagnosis = state.medical_diagnosis ?? ''
   const patientId = state.patient_id ?? '1'
+  const sessionId = state.session_id ?? null
 
   // Restore any previously entered draft so data survives back-and-forth navigation
   const draft = state.plan_data
@@ -51,8 +54,11 @@ export default function CreateTreatmentPlan() {
     end_date: draft?.end_date ?? '',
     notes: draft?.notes ?? '',
   })
+  const createPlan = useCreatePlan()
+  const isSaving = createPlan.isPending
+
   const [errors, setErrors] = useState<FormErrors>({})
-  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [exercises, setExercises] = useState<ExerciseEntry[]>([])
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -94,27 +100,29 @@ export default function CreateTreatmentPlan() {
     setExercises((prev) => prev.filter((ex) => ex.id !== id))
   }
 
-  // Save: 800 ms simulation → return to CreateVisitSummary with the saved plan
+  // Save: POST to /visit-summary/plan with session_id linking the plan to the visit summary
   function handleSave(): void {
     if (!validate()) return
-    setIsSaving(true)
-    setTimeout(() => {
-      setIsSaving(false)
-      navigate(`/patient/${patientId}/visit-summaries/new`, {
-        state: {
-          saved_plan: form,
-          medical_diagnosis: medicalDiagnosis,
-        },
-      })
-    }, 800)
-  }
-
-  // Back: carry the current draft so CreateVisitSummary can restore it on return
-  function handleBack(): void {
-    navigate(`/patient/${patientId}/visit-summaries/new`, {
-      state: {
-        plan_data: form,
-        medical_diagnosis: medicalDiagnosis,
+    if (sessionId === null) {
+      setSaveError('No session linked. Please save a visit summary first.')
+      return
+    }
+    setSaveError(null)
+    const payload = {
+      session_id: sessionId,
+      goal: form.goal,
+      start_date: form.start_date,
+      end_date: form.end_date,
+    }
+    console.log('[DEBUG] POST /visit-summary/plan payload:', payload)
+    createPlan.mutate(payload, {
+      onSuccess: (data) => {
+        console.log('[DEBUG] Plan created, plan_id:', data.plan_id, 'session_id:', data.session_id)
+        navigate(`/patient/${patientId}/visit-summaries`)
+      },
+      onError: (err) => {
+        console.error('[DEBUG] Plan save failed:', err)
+        setSaveError('Failed to save treatment plan. Please try again.')
       },
     })
   }
@@ -126,7 +134,11 @@ export default function CreateTreatmentPlan() {
       <main className="pt-16">
         {/* ── Back navigation ── */}
         <div className="patient-nav">
-          <button type="button" className="patient-nav__back" onClick={handleBack}>
+          <button
+            type="button"
+            className="patient-nav__back"
+            onClick={() => navigate(`/patient/${patientId}/visit-summaries`)}
+          >
             <ChevronLeft size={20} />
           </button>
           <h1 className="patient-nav__title">New Treatment Plan</h1>
@@ -268,15 +280,12 @@ export default function CreateTreatmentPlan() {
           </div>
 
           {/* ── Actions ── */}
+          {saveError && (
+            <p className="ctp-error-msg" style={{ textAlign: 'right', marginBottom: '0.5rem' }}>
+              {saveError}
+            </p>
+          )}
           <div className="ctp-actions">
-            <button
-              type="button"
-              className="ctp-btn-back"
-              onClick={handleBack}
-              disabled={isSaving}
-            >
-              Back
-            </button>
             <button
               type="button"
               className="ctp-btn-save"

--- a/client/src/pages/create-visit-summary/CreateVisitSummary.css
+++ b/client/src/pages/create-visit-summary/CreateVisitSummary.css
@@ -98,9 +98,9 @@
 }
 
 .cvs-label {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
-  color: var(--color-text-secondary);
+  color: #1e293b;
 }
 
 .cvs-required {
@@ -116,7 +116,7 @@
   border: 1.5px solid var(--color-border);
   background-color: #fff;
   font-family: var(--font-family);
-  font-size: 14px;
+  font-size: 15px;
   color: var(--color-text-primary);
   transition: border-color 0.15s, box-shadow 0.15s;
   outline: none;

--- a/client/src/pages/create-visit-summary/CreateVisitSummary.tsx
+++ b/client/src/pages/create-visit-summary/CreateVisitSummary.tsx
@@ -1,9 +1,11 @@
-import { useState } from 'react'
-import { useNavigate, useParams, useLocation } from 'react-router-dom'
-import { ChevronLeft, Phone, Mail, Target, ClipboardList, CheckCircle2 } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ChevronLeft, Phone, Mail, ClipboardList } from 'lucide-react'
 import { useAtomValue } from 'jotai'
 import { authAtom } from '@/store/authAtom'
 import TopNav from '@/components/TopNav'
+import { useVisitSummary } from '@/hooks/useVisitSummaries'
+import { useCreateVisitSummary } from '@/hooks/useCreateVisitSummary'
 
 import '../patient-details/PatientDetails.css'
 import './CreateVisitSummary.css'
@@ -16,12 +18,6 @@ const PATIENT = {
   birthDate: '1981-03-15',
   phone: '+972-50-000-0001',
   email: 'john.smith@example.com',
-}
-
-// ── Mock rehabilitation goal ─────────────────────────────────────────────────
-const REHAB_GOAL = {
-  title: 'Full shoulder range of motion recovery',
-  progressPercent: 42,
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -69,20 +65,35 @@ interface FormErrors {
 export default function CreateVisitSummary() {
   const navigate = useNavigate()
   const { id } = useParams<{ id: string }>()
-  const location = useLocation()
   const auth = useAtomValue(authAtom)
 
-  // Plan data returned from CreateTreatmentPlan (draft = "Back" clicked, saved = "Save" clicked)
-  type PlanState = { goal: string; start_date: string; end_date: string; notes: string }
-  const locationState = location.state as { plan_data?: PlanState; saved_plan?: PlanState } | null
-  const planDraft = locationState?.plan_data ?? null
-  const savedPlan = locationState?.saved_plan ?? null
+  // ── Real API data (API-first, mock fallback) ─────────────────────────────
+  const { data: patientApiData, isLoading: isLoadingPatient } = useVisitSummary(id)
+
+  useEffect(() => {
+    console.log('[DEBUG] Route param id (patient_id sent to API):', id)
+  }, [id])
+
+  useEffect(() => {
+    if (patientApiData) {
+      console.log('[DEBUG] useVisitSummary response:', patientApiData)
+    }
+  }, [patientApiData])
+
+  const displayPatient = {
+    id:        patientApiData?.patient_id        ?? PATIENT.id,
+    firstName: patientApiData?.patient_first_name ?? PATIENT.firstName,
+    lastName:  patientApiData?.patient_last_name  ?? PATIENT.lastName,
+    birthDate: patientApiData?.birth_date         ?? PATIENT.birthDate,
+    phone:     patientApiData?.phone              ?? PATIENT.phone,
+    email:     patientApiData?.email              ?? PATIENT.email,
+  }
 
   // Derive session type from user role — not editable
   const isPhysicalTherapy = auth?.role !== 'FITNESS_TRAINER'
   const sessionType = isPhysicalTherapy ? 'Physical Therapy' : 'Training'
 
-  const age = calculateAge(PATIENT.birthDate)
+  const age = calculateAge(displayPatient.birthDate)
 
   const [form, setForm] = useState<FormState>({
     date: getTodayString(),
@@ -93,8 +104,11 @@ export default function CreateVisitSummary() {
     recommendations: '',
   })
 
+  const createVisitSummary = useCreateVisitSummary()
+  const isSaving = createVisitSummary.isPending
+
   const [errors, setErrors] = useState<FormErrors>({})
-  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   function handleChange(field: keyof FormState, value: string): void {
     setForm((prev) => ({ ...prev, [field]: value }))
@@ -113,46 +127,72 @@ export default function CreateVisitSummary() {
     return Object.keys(newErrors).length === 0
   }
 
+  function buildPayload() {
+    const patientId = id ?? displayPatient.id
+    return {
+      patientId,
+      payload: {
+        visit_date: form.date,
+        visit_time: form.time,
+        treatment_area: form.treatmentArea,
+        medical_diagnosis: form.medicalDiagnosis,
+        description: form.visitNotes,
+        recommendations: form.recommendations || undefined,
+        patient_id: patientId,
+        therapist_id: auth?.id ?? '',
+        therapist_role: auth?.role ?? '',
+      },
+    }
+  }
+
+  // Save summary only — navigate to the list on success
   function handleSave(): void {
+    if (!auth) { setSaveError('Session expired. Please log in again.'); return }
     if (!validate()) return
-    setIsSaving(true)
-    // Simulate async API call
-    setTimeout(() => {
-      setIsSaving(false)
-      navigate(`/patient/${id ?? PATIENT.id}/visit-summaries`)
-    }, 800)
+    setSaveError(null)
+    const { patientId, payload } = buildPayload()
+    console.log('[DEBUG] POST /visit-summary payload:', payload)
+    createVisitSummary.mutate(payload, {
+      onSuccess: (data) => {
+        console.log('[DEBUG] Visit summary created, session_id:', data.session_id)
+        console.log('[DEBUG] Navigating to:', `/patient/${patientId}/visit-summaries`)
+        navigate(`/patient/${patientId}/visit-summaries`)
+      },
+      onError: (err) => {
+        console.error('[DEBUG] Save failed:', err)
+        setSaveError('Failed to save visit summary. Please try again.')
+      },
+    })
+  }
+
+  // Save summary first, then navigate to Create Treatment Plan with session_id
+  function handleSaveAndCreatePlan(): void {
+    if (!auth) { setSaveError('Session expired. Please log in again.'); return }
+    if (!validate()) return
+    setSaveError(null)
+    const { patientId, payload } = buildPayload()
+    console.log('[DEBUG] POST /visit-summary (save & plan) payload:', payload)
+    createVisitSummary.mutate(payload, {
+      onSuccess: (data) => {
+        console.log('[DEBUG] Visit summary created, session_id:', data.session_id)
+        console.log('[DEBUG] Navigating to /create-treatment-plan with session_id:', data.session_id)
+        navigate('/create-treatment-plan', {
+          state: {
+            patient_id: patientId,
+            session_id: data.session_id,
+            medical_diagnosis: form.medicalDiagnosis,
+          },
+        })
+      },
+      onError: (err) => {
+        console.error('[DEBUG] Save & create plan failed:', err)
+        setSaveError('Failed to save visit summary. Please try again.')
+      },
+    })
   }
 
   function handleCancel(): void {
-    navigate(`/patient/${id ?? PATIENT.id}/visit-summaries`)
-  }
-
-  // True once the user has saved a treatment plan in this session.
-  // In production this would come from an API call (patient already has a plan record).
-  const hasExistingPlan = savedPlan !== null
-
-  // Case A — no existing plan: open a blank form
-  function handleCreateNewPlan(): void {
-    navigate('/create-treatment-plan', {
-      state: {
-        medical_diagnosis: form.medicalDiagnosis,
-        patient_id: id ?? PATIENT.id,
-        isUpdate: false,
-        plan_data: undefined,
-      },
-    })
-  }
-
-  // Case B — plan exists: pre-fill with the saved data for editing
-  function handleUpdatePlan(): void {
-    navigate('/create-treatment-plan', {
-      state: {
-        medical_diagnosis: form.medicalDiagnosis,
-        patient_id: id ?? PATIENT.id,
-        isUpdate: true,
-        plan_data: savedPlan ?? planDraft,
-      },
-    })
+    navigate(`/patient/${id ?? displayPatient.id}/visit-summaries`)
   }
 
   return (
@@ -173,30 +213,54 @@ export default function CreateVisitSummary() {
 
           {/* 1. Patient Profile Card */}
           <div className="patient-profile-card">
-            <div className="patient-profile-card__avatar">
-              {getInitials(PATIENT.firstName, PATIENT.lastName)}
-            </div>
-            <div className="patient-profile-card__info">
-              <p className="patient-profile-card__name">
-                {PATIENT.firstName} {PATIENT.lastName}
+            {isLoadingPatient ? (
+              <p style={{ padding: '0.5rem', color: 'var(--color-primary)' }}>
+                Loading patient data…
               </p>
-              <div className="patient-profile-card__meta-row">
-                <span>ID: #{PATIENT.id}</span>
-                <span className="patient-profile-card__sep">|</span>
-                <span>{age} years old</span>
-                <span className="patient-profile-card__sep">|</span>
-                <a href={`tel:${PATIENT.phone}`} className="patient-profile-card__contact">
-                  <Phone size={13} className="patient-profile-card__contact-icon" />
-                  {PATIENT.phone}
-                </a>
-                <span className="patient-profile-card__sep">|</span>
-                <a href={`mailto:${PATIENT.email}`} className="patient-profile-card__contact">
-                  <Mail size={13} className="patient-profile-card__contact-icon" />
-                  {PATIENT.email}
-                </a>
-              </div>
-            </div>
+            ) : (
+              <>
+                <div className="patient-profile-card__avatar">
+                  {getInitials(displayPatient.firstName, displayPatient.lastName)}
+                </div>
+                <div className="patient-profile-card__info">
+                  <p className="patient-profile-card__name">
+                    {displayPatient.firstName} {displayPatient.lastName}
+                  </p>
+                  <div className="patient-profile-card__meta-row">
+                    <span>ID: #{displayPatient.id}</span>
+                    <span className="patient-profile-card__sep">|</span>
+                    <span>{age} years old</span>
+                    <span className="patient-profile-card__sep">|</span>
+                    <a href={`tel:${displayPatient.phone}`} className="patient-profile-card__contact">
+                      <Phone size={13} className="patient-profile-card__contact-icon" />
+                      {displayPatient.phone}
+                    </a>
+                    <span className="patient-profile-card__sep">|</span>
+                    <a href={`mailto:${displayPatient.email}`} className="patient-profile-card__contact">
+                      <Mail size={13} className="patient-profile-card__contact-icon" />
+                      {displayPatient.email}
+                    </a>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
+
+          {/* 🛠 TEMP DEBUG — remove once real data is verified */}
+          {patientApiData && (
+            <pre style={{
+              background: '#1e1e2e',
+              color: '#cdd6f4',
+              fontSize: '0.75rem',
+              padding: '0.75rem 1rem',
+              borderRadius: '8px',
+              overflowX: 'auto',
+              border: '1px solid #45475a',
+            }}>
+              <strong style={{ color: '#a6e3a1' }}>[DEBUG] Backend response:</strong>
+              {'\n'}{JSON.stringify(patientApiData, null, 2)}
+            </pre>
+          )}
 
           {/* Session type badge — role-derived, single badge shown */}
           <div className="cvs-session-row">
@@ -309,46 +373,7 @@ export default function CreateVisitSummary() {
             </div>
           </div>
 
-          {/* 4. Rehabilitation Goal — shows saved treatment plan goal if available */}
-          <div className="cvs-card cvs-card--goal">
-            <div className="cvs-card__title-row">
-              <Target size={16} className="cvs-card__title-icon" />
-              <h2 className="cvs-card__title">
-                {savedPlan ? 'Treatment Plan Goal' : 'Current Rehabilitation Goal'}
-              </h2>
-              {savedPlan && (
-                <span className="cvs-plan-saved-badge">
-                  <CheckCircle2 size={12} />
-                  Plan Saved
-                </span>
-              )}
-            </div>
-
-            <p className="cvs-goal__text">
-              {savedPlan ? savedPlan.goal : REHAB_GOAL.title}
-            </p>
-
-            {savedPlan ? (
-              <p className="cvs-plan-dates">
-                {savedPlan.start_date} &mdash; {savedPlan.end_date}
-              </p>
-            ) : (
-              <div className="cvs-goal__progress">
-                <div className="cvs-goal__progress-header">
-                  <span className="cvs-goal__progress-label">Overall Progress</span>
-                  <span className="cvs-goal__progress-pct">{REHAB_GOAL.progressPercent}%</span>
-                </div>
-                <div className="cvs-goal__progress-track">
-                  <div
-                    className="cvs-goal__progress-fill"
-                    style={{ width: `${REHAB_GOAL.progressPercent}%` }}
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* 5. Action Buttons */}
+          {/* 4. Action Buttons */}
           <div className="cvs-actions">
             {/* Far left — tertiary */}
             <button
@@ -360,40 +385,20 @@ export default function CreateVisitSummary() {
               Cancel
             </button>
 
-            {/* Far right — plan button(s) + primary save */}
+            {/* Far right — plan button + primary save */}
             <div className="cvs-actions__right">
-              {hasExistingPlan ? (
-                <>
-                  <button
-                    type="button"
-                    className="cvs-btn-plan"
-                    disabled={isSaving}
-                    onClick={handleCreateNewPlan}
-                  >
-                    <ClipboardList size={15} className="cvs-btn-plan__icon" />
-                    Create New Plan
-                  </button>
-                  <button
-                    type="button"
-                    className="cvs-btn-plan"
-                    disabled={isSaving}
-                    onClick={handleUpdatePlan}
-                  >
-                    <ClipboardList size={15} className="cvs-btn-plan__icon" />
-                    Update Current Plan
-                  </button>
-                </>
-              ) : (
-                <button
-                  type="button"
-                  className="cvs-btn-plan"
-                  disabled={isSaving}
-                  onClick={handleCreateNewPlan}
-                >
-                  <ClipboardList size={15} className="cvs-btn-plan__icon" />
-                  Create Treatment Plan
-                </button>
+              {saveError && (
+                <p className="cvs-error-msg" style={{ alignSelf: 'center' }}>{saveError}</p>
               )}
+              <button
+                type="button"
+                className="cvs-btn-plan"
+                disabled={isSaving}
+                onClick={handleSaveAndCreatePlan}
+              >
+                <ClipboardList size={15} className="cvs-btn-plan__icon" />
+                {isSaving ? 'Saving…' : 'Save & Create Treatment Plan'}
+              </button>
               <button
                 type="button"
                 className="cvs-btn-save"

--- a/client/src/pages/dev/DevLogin.tsx
+++ b/client/src/pages/dev/DevLogin.tsx
@@ -1,0 +1,82 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// DEV ONLY — delete this file and remove the /dev-login route from App.tsx
+// before shipping to production.
+// ─────────────────────────────────────────────────────────────────────────────
+import { useNavigate } from 'react-router-dom'
+import { useSetAtom } from 'jotai'
+import { authAtom } from '@/store/authAtom'
+import type { LoginResponse } from '@/types'
+
+const DEV_TARGET = '/patient/P100/visit-summaries/new'
+
+const DEV_USERS: { label: string; auth: LoginResponse }[] = [
+  {
+    label: 'Bob Johnson — T200 (Physiotherapist)',
+    auth: { id: 'T200', email: 'bob@physio.com', role: 'PHYSIOTHERAPIST', first_name: 'Bob' },
+  },
+  {
+    label: 'Charlie Davis — F300 (Fitness Trainer)',
+    auth: { id: 'F300', email: 'charlie@gym.com', role: 'FITNESS_TRAINER', first_name: 'Charlie' },
+  },
+]
+
+export default function DevLogin() {
+  const navigate = useNavigate()
+  const setAuth = useSetAtom(authAtom)
+
+  function loginAs(user: LoginResponse) {
+    setAuth(user)
+    navigate(DEV_TARGET)
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: '1.5rem',
+      background: '#1a1a2e',
+      fontFamily: 'monospace',
+    }}>
+      <div style={{
+        background: '#ff4444',
+        color: '#fff',
+        padding: '0.4rem 1rem',
+        borderRadius: '4px',
+        fontWeight: 700,
+        fontSize: '0.75rem',
+        letterSpacing: '0.1em',
+      }}>
+        ⚠ DEV ONLY — NOT FOR PRODUCTION
+      </div>
+
+      <h1 style={{ color: '#e2e8f0', fontSize: '1.1rem', margin: 0 }}>
+        Quick Dev Login → <code style={{ color: '#90cdf4' }}>{DEV_TARGET}</code>
+      </h1>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', width: '320px' }}>
+        {DEV_USERS.map((u) => (
+          <button
+            key={u.auth.id}
+            type="button"
+            onClick={() => loginAs(u.auth)}
+            style={{
+              padding: '0.75rem 1.25rem',
+              background: '#2d3748',
+              color: '#e2e8f0',
+              border: '1px solid #4a5568',
+              borderRadius: '8px',
+              cursor: 'pointer',
+              fontSize: '0.875rem',
+              textAlign: 'left',
+            }}
+          >
+            <strong>{u.auth.id}</strong> · {u.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/client/src/pages/patient-details/PatientDetails.tsx
+++ b/client/src/pages/patient-details/PatientDetails.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { ChevronLeft, Phone, Mail, Calendar, User, Activity } from 'lucide-react'
 import TopNav from '@/components/TopNav'
 import InfoCard from '@/components/InfoCard'
@@ -81,8 +81,11 @@ function formatDate(iso: string): string {
 
 export default function PatientDetails() {
   const navigate = useNavigate()
+  const { id: routePatientId } = useParams<{ id: string }>()
   const [showTrainingComingSoon, setShowTrainingComingSoon] = useState(false)
   const { patient, alerts, visitSummary, treatmentPlan, trainingPlan } = MOCK
+
+  console.log('[DEBUG] PatientDetails route param id:', routePatientId)
 
   const patientAlerts = alerts.filter((a) => a.patientId === patient.id)
   const age = calculateAge(patient.birthDate)
@@ -143,7 +146,7 @@ export default function PatientDetails() {
           {/* Three main cards */}
           <div className="patient-cards-grid">
             {/* Visit Summaries */}
-            <InfoCard title="Visit Summaries" actionLabel="View All Summaries" onAction={() => navigate(`/patient/${patient.id}/visit-summaries`)}>
+            <InfoCard title="Visit Summaries" actionLabel="View All Summaries" onAction={() => navigate(`/patient/${routePatientId}/visit-summaries`)}>
               <div className="patient-visit__rows">
                 <div className="patient-visit__row">
                   <span className="patient-visit__label">
@@ -170,7 +173,7 @@ export default function PatientDetails() {
             <InfoCard
               title="Treatment Plan"
               actionLabel="Go to Current Treatment Plan"
-              onAction={() => navigate(`/patient/${patient.id}/treatment-plans`)}
+              onAction={() => navigate(`/patient/${routePatientId}/treatment-plans`)}
             >
               <div className="patient-plan__rows">
                 <div className="patient-plan__row">

--- a/client/src/store/authAtom.ts
+++ b/client/src/store/authAtom.ts
@@ -1,4 +1,4 @@
-import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 import type { LoginResponse } from '@/types'
 
-export const authAtom = atom<LoginResponse | null>(null)
+export const authAtom = atomWithStorage<LoginResponse | null>('auth', null)

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -146,3 +146,29 @@ export const VisitType = {
   PHYSIOTHERAPIST: "PHYSIOTHERAPIST",
   FITNESS: "FITNESS"
 }
+
+// ── Visit Summary domain types ────────────────────────────────────────────────
+
+export interface VisitSummaryPatientData {
+  patient_id: string
+  patient_first_name: string
+  patient_last_name: string
+  phone: string
+  birth_date: string
+  email: string
+  plan_id: number | null
+  visit_date: string
+  visit_time: string
+}
+
+export interface SessionListItem {
+  session_id: number
+  visit_date: string
+  visit_time: string
+  visit_type: string
+  treatment_area: string
+  medical_diagnosis: string
+  description: string
+  therapist_first_name: string
+  therapist_last_name: string
+}

--- a/server/app/api/visit_summary_routes.py
+++ b/server/app/api/visit_summary_routes.py
@@ -3,9 +3,12 @@ from fastapi import APIRouter, Depends
 from app.dal.visit_summary_repository import VisitSummaryRepository
 from app.db.session import get_db
 from app.models.visit_summary.visit_summary import (
+    CreatePlanRequest,
+    CreatePlanResponse,
     CreateVisitSummaryRequest,
     CreateVisitSummaryResponse,
     PatientDetails,
+    SessionListItem,
 )
 from app.services.visit_summary_services import VisitSummaryServices
 
@@ -32,6 +35,28 @@ async def get_patient_details(patient_id: str, db=Depends(get_db)) -> PatientDet
     return await visit_summary_service.get_patient_details(patient_id)
 
 
+@visit_summary_router.get(
+    "/sessions/{patient_id}",
+    tags=["Visit Summary"],
+    response_model=list[SessionListItem],
+)
+async def get_sessions_by_patient(
+    patient_id: str, db=Depends(get_db)
+) -> list[SessionListItem]:
+    """Return all active sessions for a patient, newest first.
+
+    Args:
+        patient_id: The unique identifier of the patient.
+        db: Database cursor injected by FastAPI.
+
+    Returns:
+        A list of SessionListItem for the requested patient.
+    """
+    visit_summary_repository = VisitSummaryRepository(db=db)
+    visit_summary_service = VisitSummaryServices(repository=visit_summary_repository)
+    return await visit_summary_service.get_sessions_by_patient(patient_id)
+
+
 @visit_summary_router.post(
     "",
     tags=["Visit Summary"],
@@ -52,3 +77,25 @@ async def create_visit_summary(
     visit_summary_repository = VisitSummaryRepository(db=db)
     visit_summary_service = VisitSummaryServices(repository=visit_summary_repository)
     return await visit_summary_service.create_visit_summary(request)
+
+
+@visit_summary_router.post(
+    "/plan",
+    tags=["Visit Summary"],
+    response_model=CreatePlanResponse,
+)
+async def create_plan(
+    request: CreatePlanRequest, db=Depends(get_db)
+) -> CreatePlanResponse:
+    """Create a treatment plan linked to an existing session.
+
+    Args:
+        request: The plan payload including session_id, goal, and date range.
+        db: Database cursor injected by FastAPI.
+
+    Returns:
+        CreatePlanResponse containing the new plan_id and linked session_id.
+    """
+    visit_summary_repository = VisitSummaryRepository(db=db)
+    visit_summary_service = VisitSummaryServices(repository=visit_summary_repository)
+    return await visit_summary_service.create_plan(request)

--- a/server/app/dal/visit_summary_repository.py
+++ b/server/app/dal/visit_summary_repository.py
@@ -2,9 +2,12 @@ from aiomysql import DictCursor
 
 from app.models.patients.visit_type import VisitType
 from app.models.visit_summary.visit_summary import (
+    CreatePlanRequest,
+    CreatePlanResponse,
     CreateVisitSummaryRequest,
     CreateVisitSummaryResponse,
     PatientDetails,
+    SessionListItem,
 )
 
 
@@ -97,3 +100,65 @@ class VisitSummaryRepository:
         await self.cursor.execute("SELECT LAST_INSERT_ID() AS session_id")
         row = await self.cursor.fetchone()
         return CreateVisitSummaryResponse.model_validate(row)
+
+    async def get_sessions_by_patient(self, patient_id: str) -> list[SessionListItem]:
+        """Fetch all active sessions for a patient, newest first.
+
+        Args:
+            patient_id: The unique identifier of the patient.
+
+        Returns:
+            A list of SessionListItem instances ordered by date descending.
+        """
+        await self.cursor.execute(
+            query="""
+                SELECT
+                    s.session_id,
+                    s.visit_date,
+                    s.visit_time,
+                    s.visit_type,
+                    s.treatment_area,
+                    s.medical_diagnosis,
+                    s.description,
+                    u_therapist.first_name AS therapist_first_name,
+                    u_therapist.last_name  AS therapist_last_name
+                FROM sessions s
+                JOIN registered_users u_therapist
+                    ON s.therapist_id   = u_therapist.user_id
+                   AND s.therapist_role = u_therapist.user_role
+                WHERE s.patient_id     = %s
+                  AND s.session_status = 'ACTIVE'
+                ORDER BY s.visit_date DESC, s.visit_time DESC
+            """,
+            args=(patient_id,),
+        )
+        rows = await self.cursor.fetchall()
+        return [SessionListItem.model_validate(row) for row in rows]
+
+    async def create_plan(self, request: CreatePlanRequest) -> CreatePlanResponse:
+        """Insert a new treatment plan linked to a session and return its generated plan_id.
+
+        Args:
+            request: The plan data including the session_id that links it to a visit summary.
+
+        Returns:
+            A CreatePlanResponse containing the new plan_id and the linked session_id.
+        """
+        await self.cursor.execute(
+            query="""
+                INSERT INTO plans (session_id, goal, start_date, end_date)
+                VALUES (%s, %s, %s, %s)
+            """,
+            args=(
+                request.session_id,
+                request.goal,
+                request.start_date,
+                request.end_date,
+            ),
+        )
+        await self.cursor.execute(
+            "SELECT LAST_INSERT_ID() AS plan_id, %s AS session_id",
+            args=(request.session_id,),
+        )
+        row = await self.cursor.fetchone()
+        return CreatePlanResponse.model_validate(row)

--- a/server/app/models/visit_summary/visit_summary.py
+++ b/server/app/models/visit_summary/visit_summary.py
@@ -1,6 +1,6 @@
 import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.models.enums.role import Role
 
@@ -38,4 +38,54 @@ class CreateVisitSummaryRequest(BaseModel):
 class CreateVisitSummaryResponse(BaseModel):
     """Response returned after a visit summary is created."""
 
+    session_id: int
+
+
+class SessionListItem(BaseModel):
+    """A single session row returned in the patient's visit-summary list."""
+
+    session_id: int
+    visit_date: datetime.date
+    visit_time: datetime.time
+    visit_type: str
+    treatment_area: str
+    medical_diagnosis: str
+    description: str
+    therapist_first_name: str
+    therapist_last_name: str
+
+    @field_validator("visit_time", mode="before")
+    @classmethod
+    def coerce_timedelta_to_time(cls, value: object) -> object:  # type: ignore[override]
+        """Convert aiomysql timedelta to datetime.time for TIME columns.
+
+        Args:
+            value: The raw value from the database cursor.
+
+        Returns:
+            A datetime.time if value is a timedelta, otherwise the value unchanged.
+        """
+        if isinstance(value, datetime.timedelta):
+            total_seconds = int(value.total_seconds())
+            return datetime.time(
+                total_seconds // 3600,
+                (total_seconds % 3600) // 60,
+                total_seconds % 60,
+            )
+        return value
+
+
+class CreatePlanRequest(BaseModel):
+    """Request body for creating a new treatment plan linked to a session."""
+
+    session_id: int
+    goal: str
+    start_date: datetime.date
+    end_date: datetime.date
+
+
+class CreatePlanResponse(BaseModel):
+    """Response returned after a treatment plan is created."""
+
+    plan_id: int
     session_id: int

--- a/server/app/services/visit_summary_services.py
+++ b/server/app/services/visit_summary_services.py
@@ -4,9 +4,12 @@ from app.dal.visit_summary_repository import VisitSummaryRepository
 from app.models.enums.role import Role
 from app.models.patients.visit_type import VisitType
 from app.models.visit_summary.visit_summary import (
+    CreatePlanRequest,
+    CreatePlanResponse,
     CreateVisitSummaryRequest,
     CreateVisitSummaryResponse,
     PatientDetails,
+    SessionListItem,
 )
 
 _ROLE_TO_VISIT_TYPE: dict[Role, VisitType] = {
@@ -62,3 +65,25 @@ class VisitSummaryServices:
                 detail="Invalid therapist role for creating a visit summary",
             )
         return await self.repository.create_visit_summary(request, visit_type)
+
+    async def get_sessions_by_patient(self, patient_id: str) -> list[SessionListItem]:
+        """Return all active sessions for a patient.
+
+        Args:
+            patient_id: The unique identifier of the patient.
+
+        Returns:
+            A list of SessionListItem instances.
+        """
+        return await self.repository.get_sessions_by_patient(patient_id)
+
+    async def create_plan(self, request: CreatePlanRequest) -> CreatePlanResponse:
+        """Persist a new treatment plan linked to the given session.
+
+        Args:
+            request: The plan payload including session_id, goal, and date range.
+
+        Returns:
+            A CreatePlanResponse with the new plan_id and linked session_id.
+        """
+        return await self.repository.create_plan(request)

--- a/server/tests/unit/api/test_visit_summary_routes.py
+++ b/server/tests/unit/api/test_visit_summary_routes.py
@@ -13,8 +13,9 @@ from app.main import app
 class _VisitSummaryStubCursor:
     """Minimal async cursor stub for visit summary tests."""
 
-    def __init__(self, fetchone_rows: list) -> None:
+    def __init__(self, fetchone_rows: list, fetchall_rows: list | None = None) -> None:
         self._fetchone_queue: deque = deque(fetchone_rows)
+        self._fetchall_rows: list = fetchall_rows if fetchall_rows is not None else []
 
     async def execute(self, *_args, **_kwargs) -> None:
         return None
@@ -22,10 +23,15 @@ class _VisitSummaryStubCursor:
     async def fetchone(self):
         return self._fetchone_queue.popleft() if self._fetchone_queue else None
 
+    async def fetchall(self) -> list:
+        return self._fetchall_rows
+
 
 class VisitSummaryRoutesTest(unittest.TestCase):
     def tearDown(self) -> None:
         app.dependency_overrides.clear()
+
+    # ── GET /visit-summary/patient/{patient_id} ──────────────────────────────
 
     def test_get_patient_details_found_returns_200(self) -> None:
         """
@@ -124,6 +130,86 @@ class VisitSummaryRoutesTest(unittest.TestCase):
 
         # ASSERT
         assert response.status_code == 404
+
+    # ── GET /visit-summary/sessions/{patient_id} ─────────────────────────────
+
+    def test_get_sessions_by_patient_returns_list(self) -> None:
+        """
+        Given two active session rows for a patient,
+        When GET /visit-summary/sessions/{patient_id} is called,
+        Then 200 is returned with both sessions in the response list.
+        """
+        # PREPARE
+        cursor = _VisitSummaryStubCursor(
+            fetchone_rows=[],
+            fetchall_rows=[
+                {
+                    "session_id": 10,
+                    "visit_date": datetime.date(2026, 4, 20),
+                    "visit_time": datetime.time(10, 0, 0),
+                    "visit_type": "PHYSIOTHERAPIST",
+                    "treatment_area": "Knee",
+                    "medical_diagnosis": "ACL tear",
+                    "description": "Initial assessment",
+                    "therapist_first_name": "Bob",
+                    "therapist_last_name": "Cohen",
+                },
+                {
+                    "session_id": 11,
+                    "visit_date": datetime.date(2026, 4, 10),
+                    "visit_time": datetime.time(14, 30, 0),
+                    "visit_type": "FITNESS",
+                    "treatment_area": "Shoulder",
+                    "medical_diagnosis": "Rotator cuff",
+                    "description": "Strength work",
+                    "therapist_first_name": "Dana",
+                    "therapist_last_name": "Levi",
+                },
+            ],
+        )
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.get("/visit-summary/sessions/P100")
+
+        # ASSERT
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 2
+        assert body[0]["session_id"] == 10
+        assert body[0]["visit_type"] == "PHYSIOTHERAPIST"
+        assert body[0]["therapist_first_name"] == "Bob"
+        assert body[1]["session_id"] == 11
+        assert body[1]["visit_type"] == "FITNESS"
+
+    def test_get_sessions_by_patient_empty_returns_empty_list(self) -> None:
+        """
+        Given no active sessions for a patient,
+        When GET /visit-summary/sessions/{patient_id} is called,
+        Then 200 is returned with an empty list.
+        """
+        # PREPARE
+        cursor = _VisitSummaryStubCursor(fetchone_rows=[], fetchall_rows=[])
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.get("/visit-summary/sessions/P999")
+
+        # ASSERT
+        assert response.status_code == 200
+        assert response.json() == []
+
+    # ── POST /visit-summary ───────────────────────────────────────────────────
 
     def test_create_visit_summary_physiotherapist_returns_session_id(self) -> None:
         """
@@ -270,6 +356,66 @@ class VisitSummaryRoutesTest(unittest.TestCase):
         # ACT
         client = TestClient(app)
         response = client.post("/visit-summary", json={"treatment_area": "Knee"})
+
+        # ASSERT
+        assert response.status_code == 422
+
+    # ── POST /visit-summary/plan ──────────────────────────────────────────────
+
+    def test_create_plan_returns_plan_id_and_session_id(self) -> None:
+        """
+        Given a valid plan request with an existing session_id,
+        When POST /visit-summary/plan is called,
+        Then 200 is returned with the new plan_id and the linked session_id.
+        """
+        # PREPARE
+        cursor = _VisitSummaryStubCursor(
+            fetchone_rows=[{"plan_id": 5, "session_id": 10}]
+        )
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.post(
+            "/visit-summary/plan",
+            json={
+                "session_id": 10,
+                "goal": "Restore full range of motion in shoulder",
+                "start_date": "2026-05-01",
+                "end_date": "2026-07-01",
+            },
+        )
+
+        # ASSERT
+        assert response.status_code == 200
+        body = response.json()
+        assert body["plan_id"] == 5
+        assert body["session_id"] == 10
+
+    def test_create_plan_missing_required_fields_returns_422(self) -> None:
+        """
+        Given a plan request missing the required goal field,
+        When POST /visit-summary/plan is called,
+        Then 422 Unprocessable Entity is returned.
+        """
+        # PREPARE
+        cursor = _VisitSummaryStubCursor(fetchone_rows=[])
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.post(
+            "/visit-summary/plan",
+            json={"session_id": 10},
+        )
 
         # ASSERT
         assert response.status_code == 422


### PR DESCRIPTION
- Added `useCreatePlan` and `useCreateVisitSummary` hooks for managing API interactions.
- Updated `CreateTreatmentPlan` to save treatment plans with session linkage.
- Enhanced `CreateVisitSummary` to create visit summaries and navigate to treatment plan creation.
- Introduced new API endpoints for creating treatment plans and fetching patient sessions.
- Updated database repository and models to support new plan creation functionality.
- Added unit tests for new API routes and functionalities.
- Improved error handling and user feedback in the UI for saving plans and summaries.