### PR TITLE
feat: Enhance treatment plan functionality to support FITNESS visit type

### DIFF
--- a/client/src/components/TopNav.tsx
+++ b/client/src/components/TopNav.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useAtomValue } from 'jotai'
+import { authAtom } from '@/store/authAtom'
 import { LogoIcon } from '@/pages/auth/AuthLayout'
 import './TopNav.css'
-
-interface TopNavProps {
-  doctorName: string
-}
 
 const MENU_ITEMS = [
   {
@@ -43,7 +41,9 @@ const MENU_ITEMS = [
   },
 ]
 
-export default function TopNav({ doctorName }: TopNavProps) {
+export default function TopNav() {
+  const auth = useAtomValue(authAtom)
+  const displayName = auth ? `${auth.first_name} ${auth.last_name}`.trim() : ''
   const [menuOpen, setMenuOpen] = useState(false)
   const navigate = useNavigate()
 
@@ -61,9 +61,11 @@ export default function TopNav({ doctorName }: TopNavProps) {
 
           {/* Right side */}
           <div className="flex items-center gap-4">
-            <span className="hidden sm:block text-sm font-medium text-slate-500">
-              Dr. {doctorName}
-            </span>
+            {displayName && (
+              <span className="hidden sm:block text-sm font-medium text-slate-500">
+                {displayName}
+              </span>
+            )}
             <button
               className="flex items-center justify-center w-9 h-9 rounded-xl text-slate-500 hover:bg-slate-100 active:bg-slate-200 transition-colors border-0 bg-transparent cursor-pointer"
               onClick={() => setMenuOpen(true)}

--- a/client/src/hooks/useTreatmentPlan.ts
+++ b/client/src/hooks/useTreatmentPlan.ts
@@ -22,13 +22,16 @@ export function useTreatmentPlanContext(sessionId: number | null) {
   })
 }
 
-export function usePhysiotherapyExercises() {
+export function usePlanExercises(visitType: string) {
   return useQuery<PhysiotherapyExerciseItem[]>({
-    queryKey: ['physiotherapyExercises'],
+    queryKey: ['planExercises', visitType],
     queryFn: async () => {
-      const res = await apiClient.get<PhysiotherapyExerciseItem[]>('/treatment-plan/exercises')
+      const res = await apiClient.get<PhysiotherapyExerciseItem[]>('/treatment-plan/exercises', {
+        params: { visit_type: visitType },
+      })
       return res.data
     },
+    enabled: visitType.length > 0,
   })
 }
 

--- a/client/src/pages/all-visit-summaries/AllVisitSummaries.tsx
+++ b/client/src/pages/all-visit-summaries/AllVisitSummaries.tsx
@@ -121,7 +121,7 @@ export default function AllVisitSummaries() {
 
   return (
     <div className="avs-page">
-      <TopNav doctorName="Cohen" />
+      <TopNav />
       <main className="pt-16">
         {/* ── Back navigation ── */}
         <div className="patient-nav">

--- a/client/src/pages/create-treatment-plan/CreateTreatmentPlan.tsx
+++ b/client/src/pages/create-treatment-plan/CreateTreatmentPlan.tsx
@@ -9,7 +9,7 @@ import AddExerciseModal from './AddExerciseModal'
 import type { ExerciseEntry } from './AddExerciseModal'
 import {
   useTreatmentPlanContext,
-  usePhysiotherapyExercises,
+  usePlanExercises,
   useCreateTreatmentPlan,
 } from '@/hooks/useTreatmentPlan'
 import type { CreateTreatmentPlanRequest } from '@/types'
@@ -61,7 +61,10 @@ export default function CreateTreatmentPlan() {
   })
 
   const contextQuery = useTreatmentPlanContext(sessionId)
-  const exercisesQuery = usePhysiotherapyExercises()
+  const visitType = contextQuery.data?.visit_type
+    ?? (auth?.role === 'FITNESS_TRAINER' ? 'FITNESS' : 'PHYSIOTHERAPIST')
+  const isFitness = visitType === 'FITNESS'
+  const exercisesQuery = usePlanExercises(visitType)
   const createTreatmentPlan = useCreateTreatmentPlan()
 
   const isSaving = createTreatmentPlan.isPending
@@ -95,7 +98,7 @@ export default function CreateTreatmentPlan() {
 
   function validate(): boolean {
     const newErrors: FormErrors = {}
-    if (!form.goal.trim()) newErrors.goal = 'Treatment goal is required'
+    if (!form.goal.trim()) newErrors.goal = `${visitType === 'FITNESS' ? 'Fitness' : 'Treatment'} goal is required`
     if (!form.start_date) newErrors.start_date = 'Start date is required'
     if (!form.end_date) newErrors.end_date = 'End date is required'
     else if (form.start_date && form.end_date < form.start_date) {
@@ -161,7 +164,7 @@ export default function CreateTreatmentPlan() {
 
   return (
     <div className="ctp-page">
-      <TopNav doctorName={auth?.first_name ?? 'Cohen'} />
+      <TopNav />
 
       <main className="pt-16">
         {/* ── Back navigation ── */}
@@ -173,7 +176,7 @@ export default function CreateTreatmentPlan() {
           >
             <ChevronLeft size={20} />
           </button>
-          <h1 className="patient-nav__title">New Treatment Plan</h1>
+          <h1 className="patient-nav__title">New {isFitness ? 'Fitness' : 'Treatment'} Plan</h1>
         </div>
 
         <div className="ctp-body">
@@ -245,7 +248,7 @@ export default function CreateTreatmentPlan() {
             <div className="ctp-goal__header">
               <Target size={16} className="ctp-goal__icon" />
               <span className="ctp-goal__title">
-                {auth?.role === 'FITNESS_TRAINER' ? 'Fitness' : 'Treatment'} Goal <span className="ctp-required">*</span>
+                {visitType === 'FITNESS' ? 'Fitness' : 'Treatment'} Goal <span className="ctp-required">*</span>
               </span>
             </div>
             <textarea
@@ -330,7 +333,7 @@ export default function CreateTreatmentPlan() {
                   Saving…
                 </>
               ) : (
-                'Save Treatment Plan'
+                `Save ${isFitness ? 'Fitness' : 'Treatment'} Plan`
               )}
             </button>
           </div>

--- a/client/src/pages/create-visit-summary/CreateVisitSummary.tsx
+++ b/client/src/pages/create-visit-summary/CreateVisitSummary.tsx
@@ -199,7 +199,7 @@ export default function CreateVisitSummary() {
 
   return (
     <div className="cvs-page">
-      <TopNav doctorName={auth?.first_name ?? 'Cohen'} />
+      <TopNav />
 
       <main className="pt-16">
         {/* ── Back navigation ── */}

--- a/client/src/pages/dev/DevLogin.tsx
+++ b/client/src/pages/dev/DevLogin.tsx
@@ -7,16 +7,16 @@ import { useSetAtom } from 'jotai'
 import { authAtom } from '@/store/authAtom'
 import type { LoginResponse } from '@/types'
 
-const DEV_TARGET = '/patient/P100/visit-summaries/new'
+const DEV_TARGET = '/patient/P100/visit-summaries'
 
 const DEV_USERS: { label: string; auth: LoginResponse }[] = [
   {
     label: 'Bob Johnson — T200 (Physiotherapist)',
-    auth: { id: 'T200', email: 'bob@physio.com', role: 'PHYSIOTHERAPIST', first_name: 'Bob' },
+    auth: { id: 'T200', email: 'bob@physio.com', role: 'PHYSIOTHERAPIST', first_name: 'Bob', last_name: 'Johnson' },
   },
   {
     label: 'Charlie Davis — F300 (Fitness Trainer)',
-    auth: { id: 'F300', email: 'charlie@gym.com', role: 'FITNESS_TRAINER', first_name: 'Charlie' },
+    auth: { id: 'F300', email: 'charlie@gym.com', role: 'FITNESS_TRAINER', first_name: 'Charlie', last_name: 'Davis' },
   },
 ]
 

--- a/client/src/pages/patient-details/PatientDetails.tsx
+++ b/client/src/pages/patient-details/PatientDetails.tsx
@@ -92,7 +92,7 @@ export default function PatientDetails() {
 
   return (
     <div className="patient-page">
-      <TopNav doctorName="Cohen" />
+      <TopNav />
       <main className="pt-16">
         {/* ── Back navigation ── */}
         <div className="patient-nav">

--- a/client/src/pages/physiotherapist/home/PhysiotherapistHome.tsx
+++ b/client/src/pages/physiotherapist/home/PhysiotherapistHome.tsx
@@ -1,5 +1,5 @@
-import { useLocation } from 'react-router-dom'
-
+import { useAtomValue } from 'jotai'
+import { authAtom } from '@/store/authAtom'
 import TopNav from '@/components/TopNav'
 import AlertItem from './components/AlertItem'
 import ScheduleCard from './components/ScheduleCard'
@@ -16,13 +16,13 @@ function getGreeting() {
 const TODAY = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })
 
 export default function PhysiotherapistHome() {
-  const location = useLocation()
-  const doctorName = (location.state as { firstName?: string } | null)?.firstName ?? 'Doctor'
+  const auth = useAtomValue(authAtom)
+  const displayName = auth ? `${auth.first_name} ${auth.last_name}`.trim() : 'Doctor'
   const { alerts, patients, schedule } = usePatientsList()
 
   return (
     <div className="min-h-screen bg-slate-50">
-      <TopNav doctorName={doctorName} />
+      <TopNav />
 
       <main className="pt-16">
         <div className="w-full max-w-[1280px] mx-auto px-8 py-6 pb-10">
@@ -30,7 +30,7 @@ export default function PhysiotherapistHome() {
           {/* Greeting */}
           <div className="mb-6">
             <h1 className="text-2xl font-bold text-slate-800 leading-tight">
-              {getGreeting()}, Dr. {doctorName}
+              {getGreeting()}, {displayName}
             </h1>
             <p className="text-sm text-slate-500 mt-1">{TODAY}</p>
           </div>

--- a/client/src/pages/view-treatment-plan/ViewTreatmentPlan.tsx
+++ b/client/src/pages/view-treatment-plan/ViewTreatmentPlan.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ChevronLeft, Target, Dumbbell, Stethoscope, CalendarDays, FileText } from 'lucide-react'
-import { useAtomValue } from 'jotai'
-import { authAtom } from '@/store/authAtom'
 import TopNav from '@/components/TopNav'
 import { useTreatmentPlanDetails } from '@/hooks/useTreatmentPlan'
 
@@ -26,7 +24,7 @@ function formatDate(iso: string): string {
 function PageShell({ onBack, children }: { onBack: () => void; children: React.ReactNode }) {
   return (
     <div className="vtp-page">
-      <TopNav doctorName="Cohen" />
+      <TopNav />
       <main className="pt-16">
         <div className="patient-nav">
           <button type="button" className="patient-nav__back" onClick={onBack}>
@@ -45,7 +43,6 @@ function PageShell({ onBack, children }: { onBack: () => void; children: React.R
 export default function ViewTreatmentPlan() {
   const navigate = useNavigate()
   const { planId } = useParams<{ id: string; planId?: string }>()
-  const auth = useAtomValue(authAtom)
 
   const { data, isLoading, isError } = useTreatmentPlanDetails(planId ? Number(planId) : undefined)
 
@@ -126,7 +123,7 @@ export default function ViewTreatmentPlan() {
         <div className="vtp-goal-card__header">
           <Target size={16} className="vtp-goal-card__icon" />
           <span className="vtp-goal-card__title">
-            {auth?.role === 'FITNESS_TRAINER' ? 'Fitness' : 'Treatment'} Goal
+            {data.visit_type === 'FITNESS' ? 'Fitness' : 'Treatment'} Goal
           </span>
         </div>
         <p className="vtp-goal-text">{data.goal}</p>

--- a/client/src/pages/visit-summary-detail/VisitSummaryDetail.tsx
+++ b/client/src/pages/visit-summary-detail/VisitSummaryDetail.tsx
@@ -100,7 +100,7 @@ function VisitInfoCard({ visit, onOpenPlan }: VisitInfoCardProps) {
       {onOpenPlan && (
         <div className="vsd-plan-action">
           <button type="button" className="vsd-plan-link" onClick={onOpenPlan}>
-            Open {visitTypeLabel === 'Fitness Training' ? 'Fitness' : 'Treatment'} Plan
+            Open {visit.visit_type === 'FITNESS' ? 'Fitness' : 'Treatment'} Plan
             <ArrowRight size={14} />
           </button>
         </div>
@@ -148,7 +148,7 @@ function MedicalCard({ visit }: MedicalCardProps) {
 function PageShell({ onBack, children }: { onBack: () => void; children: React.ReactNode }) {
   return (
     <div className="vsd-page">
-      <TopNav doctorName="Cohen" />
+      <TopNav />
       <main className="pt-16">
         <div className="patient-nav">
           <button type="button" className="patient-nav__back" onClick={onBack}>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -19,6 +19,7 @@ export interface LoginResponse {
   email: string
   role: ApiRole
   first_name: string
+  last_name: string
   token?: string
 }
 
@@ -278,6 +279,7 @@ export interface TreatmentPlanDetailsResponse {
   plan_id: number
   session_id: number
   medical_diagnosis: string
+  visit_type: string
   goal: string
   start_date: string
   end_date: string

--- a/server/app/api/treatment_plan_routes.py
+++ b/server/app/api/treatment_plan_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from app.dal.treatment_plan_repository import TreatmentPlanRepository
 from app.db.session import get_db
@@ -41,12 +41,14 @@ async def get_treatment_plan_context(
     tags=["Treatment Plan"],
     response_model=list[PhysiotherapyExerciseItem],
 )
-async def get_physiotherapy_exercises(
+async def get_plan_exercises(
+    visit_type: str = Query(default="PHYSIOTHERAPIST"),
     db=Depends(get_db),
 ) -> list[PhysiotherapyExerciseItem]:
-    """Return all PHYSIOTHERAPIST exercises for the add-exercise popup.
+    """Return exercises for the add-exercise popup, filtered by visit type.
 
     Args:
+        visit_type: Filter exercises by visit type (PHYSIOTHERAPIST or FITNESS).
         db: Database cursor injected by FastAPI.
 
     Returns:
@@ -54,7 +56,7 @@ async def get_physiotherapy_exercises(
     """
     repo = TreatmentPlanRepository(db=db)
     service = TreatmentPlanServices(repository=repo)
-    return await service.get_physiotherapy_exercises()
+    return await service.get_exercises(visit_type)
 
 
 @treatment_plan_router.get(

--- a/server/app/dal/treatment_plan_repository.py
+++ b/server/app/dal/treatment_plan_repository.py
@@ -42,8 +42,13 @@ class TreatmentPlanRepository:
         row = await self.cursor.fetchone()
         return TreatmentPlanContext.model_validate(row) if row else None
 
-    async def get_physiotherapy_exercises(self) -> list[PhysiotherapyExerciseItem]:
-        """Fetch all exercises that belong to the PHYSIOTHERAPIST visit type.
+    async def get_exercises_by_visit_type(
+        self, visit_type: str
+    ) -> list[PhysiotherapyExerciseItem]:
+        """Fetch all exercises that belong to the given visit type.
+
+        Args:
+            visit_type: The visit type to filter by (e.g. 'PHYSIOTHERAPIST' or 'FITNESS').
 
         Returns:
             A list of PhysiotherapyExerciseItem instances ordered by name.
@@ -54,9 +59,10 @@ class TreatmentPlanRepository:
                     exercise_id,
                     exercise_name
                 FROM exercises
-                WHERE visit_type = 'PHYSIOTHERAPIST'
+                WHERE visit_type = %s
                 ORDER BY exercise_name ASC
             """,
+            args=(visit_type,),
         )
         rows = await self.cursor.fetchall()
         return [PhysiotherapyExerciseItem.model_validate(row) for row in rows]
@@ -82,16 +88,17 @@ class TreatmentPlanRepository:
         row = await self.cursor.fetchone()
         return row is not None
 
-    async def get_valid_physiotherapy_exercise_ids(
-        self, exercise_ids: list[int]
+    async def get_valid_exercise_ids(
+        self, exercise_ids: list[int], visit_type: str
     ) -> list[int]:
-        """Return the subset of the given IDs that are PHYSIOTHERAPIST exercises.
+        """Return the subset of the given IDs that match the specified visit type.
 
         Args:
             exercise_ids: List of exercise IDs to validate.
+            visit_type: The visit type the exercises must belong to.
 
         Returns:
-            A list of exercise_id values that exist and have visit_type PHYSIOTHERAPIST.
+            A list of exercise_id values that exist and match the given visit_type.
         """
         if not exercise_ids:
             return []
@@ -101,9 +108,9 @@ class TreatmentPlanRepository:
                 SELECT exercise_id
                 FROM exercises
                 WHERE exercise_id IN ({placeholders})
-                  AND visit_type = 'PHYSIOTHERAPIST'
+                  AND visit_type = %s
             """,
-            args=tuple(exercise_ids),
+            args=(*exercise_ids, visit_type),
         )
         rows = await self.cursor.fetchall()
         return [row["exercise_id"] for row in rows]
@@ -188,6 +195,7 @@ class TreatmentPlanRepository:
                     p.plan_id,
                     p.session_id,
                     s.medical_diagnosis,
+                    s.visit_type,
                     p.goal,
                     p.start_date,
                     p.end_date,

--- a/server/app/models/treatment_plan/treatment_plan.py
+++ b/server/app/models/treatment_plan/treatment_plan.py
@@ -101,6 +101,7 @@ class TreatmentPlanDetailsResponse(BaseModel):
     plan_id: int
     session_id: int
     medical_diagnosis: str
+    visit_type: str
     goal: str
     start_date: datetime.date
     end_date: datetime.date

--- a/server/app/services/treatment_plan_services.py
+++ b/server/app/services/treatment_plan_services.py
@@ -9,8 +9,6 @@ from app.models.treatment_plan.treatment_plan import (
     TreatmentPlanDetailsResponse,
 )
 
-_PHYSIOTHERAPIST_VISIT_TYPE = "PHYSIOTHERAPIST"
-
 
 class TreatmentPlanServices:
     """Business logic for treatment plan operations."""
@@ -21,7 +19,7 @@ class TreatmentPlanServices:
     async def get_treatment_plan_context(
         self, session_id: int
     ) -> TreatmentPlanContext:
-        """Return session context or raise if the session is missing or not PHYSIOTHERAPIST.
+        """Return session context or raise if the session is missing or inactive.
 
         Args:
             session_id: The unique identifier of the session.
@@ -31,7 +29,6 @@ class TreatmentPlanServices:
 
         Raises:
             HTTPException: 404 if the session does not exist or is not active.
-            HTTPException: 400 if the session visit_type is not PHYSIOTHERAPIST.
         """
         context = await self.repository.get_treatment_plan_context(session_id)
         if not context:
@@ -39,27 +36,25 @@ class TreatmentPlanServices:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Session not found",
             )
-        if context.visit_type != _PHYSIOTHERAPIST_VISIT_TYPE:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Treatment plans can only be created for PHYSIOTHERAPIST sessions",
-            )
         return context
 
-    async def get_physiotherapy_exercises(self) -> list[PhysiotherapyExerciseItem]:
-        """Return all PHYSIOTHERAPIST exercises available for selection.
+    async def get_exercises(self, visit_type: str) -> list[PhysiotherapyExerciseItem]:
+        """Return all exercises for the given visit type, available for plan creation.
+
+        Args:
+            visit_type: The visit type to filter exercises by.
 
         Returns:
             A list of PhysiotherapyExerciseItem instances.
         """
-        return await self.repository.get_physiotherapy_exercises()
+        return await self.repository.get_exercises_by_visit_type(visit_type)
 
     async def create_treatment_plan(
         self,
         session_id: int,
         request: CreateTreatmentPlanRequest,
     ) -> CreateTreatmentPlanResponse:
-        """Validate and persist a new treatment plan with its exercises.
+        """Validate and persist a new plan with its exercises.
 
         Args:
             session_id: The session this plan belongs to (from the URL path).
@@ -70,9 +65,8 @@ class TreatmentPlanServices:
 
         Raises:
             HTTPException: 404 if the session does not exist or is not active.
-            HTTPException: 400 if the session is not a PHYSIOTHERAPIST session.
-            HTTPException: 409 if a treatment plan already exists for this session.
-            HTTPException: 400 if any selected exercise is not a PHYSIOTHERAPIST exercise.
+            HTTPException: 409 if a plan already exists for this session.
+            HTTPException: 400 if any exercise does not match the session's visit type.
         """
         context = await self.repository.get_treatment_plan_context(session_id)
         if not context:
@@ -80,27 +74,20 @@ class TreatmentPlanServices:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Session not found",
             )
-        if context.visit_type != _PHYSIOTHERAPIST_VISIT_TYPE:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Treatment plans can only be created for PHYSIOTHERAPIST sessions",
-            )
         if await self.repository.plan_exists(session_id):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail="A treatment plan already exists for this session",
+                detail="A plan already exists for this session",
             )
         requested_ids = [e.exercise_id for e in request.exercises]
-        valid_ids = await self.repository.get_valid_physiotherapy_exercise_ids(
-            requested_ids
+        valid_ids = await self.repository.get_valid_exercise_ids(
+            requested_ids, context.visit_type
         )
         invalid_ids = set(requested_ids) - set(valid_ids)
         if invalid_ids:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "One or more exercises are invalid or not of PHYSIOTHERAPIST type"
-                ),
+                detail="One or more exercises are not valid for this session's visit type",
             )
         return await self.repository.create_treatment_plan(session_id, request)
 

--- a/server/tests/unit/api/test_treatment_plan_routes.py
+++ b/server/tests/unit/api/test_treatment_plan_routes.py
@@ -91,11 +91,11 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
         # ASSERT
         assert response.status_code == 404
 
-    def test_get_context_non_physiotherapist_returns_400(self) -> None:
+    def test_get_context_fitness_session_returns_200(self) -> None:
         """
         Given the session has visit_type FITNESS,
         When GET /treatment-plan/context/{session_id} is called,
-        Then 400 Bad Request is returned.
+        Then 200 is returned with the FITNESS context (both visit types are accepted).
         """
         # PREPARE
         cursor = _TreatmentPlanStubCursor(
@@ -118,14 +118,17 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
         response = client.get("/treatment-plan/context/55")
 
         # ASSERT
-        assert response.status_code == 400
+        assert response.status_code == 200
+        body = response.json()
+        assert body["visit_type"] == "FITNESS"
+        assert body["session_id"] == 55
 
     # ── GET /treatment-plan/exercises ─────────────────────────────────────
 
     def test_get_physiotherapy_exercises_returns_list(self) -> None:
         """
         Given two PHYSIOTHERAPIST exercise rows exist in the DB,
-        When GET /treatment-plan/exercises is called,
+        When GET /treatment-plan/exercises?visit_type=PHYSIOTHERAPIST is called,
         Then 200 is returned with a list of two items.
         """
         # PREPARE
@@ -144,7 +147,7 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
 
         # ACT
         client = TestClient(app)
-        response = client.get("/treatment-plan/exercises")
+        response = client.get("/treatment-plan/exercises?visit_type=PHYSIOTHERAPIST")
 
         # ASSERT
         assert response.status_code == 200
@@ -153,6 +156,37 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
         assert body[0]["exercise_id"] == 1
         assert body[0]["exercise_name"] == "Curl"
         assert body[1]["exercise_id"] == 2
+
+    def test_get_fitness_exercises_returns_list(self) -> None:
+        """
+        Given two FITNESS exercise rows exist in the DB,
+        When GET /treatment-plan/exercises?visit_type=FITNESS is called,
+        Then 200 is returned with a list of two items.
+        """
+        # PREPARE
+        cursor = _TreatmentPlanStubCursor(
+            fetchone_rows=[],
+            fetchall_rows=[
+                {"exercise_id": 5, "exercise_name": "Wall Squats"},
+                {"exercise_id": 6, "exercise_name": "Plank"},
+            ],
+        )
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.get("/treatment-plan/exercises?visit_type=FITNESS")
+
+        # ASSERT
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 2
+        assert body[0]["exercise_id"] == 5
+        assert body[0]["exercise_name"] == "Wall Squats"
 
     # ── POST /treatment-plan/{session_id} ─────────────────────────────────
 
@@ -395,6 +429,7 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
                     "plan_id": 6,
                     "session_id": 103,
                     "medical_diagnosis": "Shoulder Impingement",
+                    "visit_type": "PHYSIOTHERAPIST",
                     "goal": "Restore full range of motion",
                     "start_date": datetime.date(2025, 1, 6),
                     "end_date": datetime.date(2025, 3, 1),
@@ -430,6 +465,7 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
         assert body["plan_id"] == 6
         assert body["session_id"] == 103
         assert body["medical_diagnosis"] == "Shoulder Impingement"
+        assert body["visit_type"] == "PHYSIOTHERAPIST"
         assert body["goal"] == "Restore full range of motion"
         assert body["notes"] is None
         assert len(body["exercises"]) == 1
@@ -457,6 +493,64 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
 
         # ASSERT
         assert response.status_code == 404
+
+    def test_create_treatment_plan_fitness_session_success(self) -> None:
+        """
+        Given a valid FITNESS session with no existing plan and valid FITNESS exercises,
+        When POST /treatment-plan/77 is called with a complete request body,
+        Then 200 is returned with the new plan_id and session_id.
+
+        fetchone sequence:
+          1. get_treatment_plan_context → FITNESS context row
+          2. plan_exists → None  (no existing plan)
+          3. LAST_INSERT_ID → {plan_id: 20}
+        fetchall: valid FITNESS exercise IDs [5]
+        """
+        # PREPARE
+        cursor = _TreatmentPlanStubCursor(
+            fetchone_rows=[
+                {
+                    "session_id": 77,
+                    "medical_diagnosis": "Knee strengthening",
+                    "visit_type": "FITNESS",
+                },
+                None,
+                {"plan_id": 20},
+            ],
+            fetchall_rows=[{"exercise_id": 5}],
+        )
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.post(
+            "/treatment-plan/77",
+            json={
+                "goal": "Build lower body strength",
+                "start_date": "2026-05-01",
+                "end_date": "2026-08-01",
+                "exercises": [
+                    {
+                        "exercise_id": 5,
+                        "reps": 12,
+                        "num_sets": 3,
+                        "weight": 0.0,
+                        "time_duration": 3,
+                        "time_unit": "Weekly",
+                    }
+                ],
+            },
+        )
+
+        # ASSERT
+        assert response.status_code == 200
+        body = response.json()
+        assert body["plan_id"] == 20
+        assert body["session_id"] == 77
 
     def test_create_treatment_plan_end_date_before_start_date_returns_422(
         self,
@@ -497,3 +591,211 @@ class TreatmentPlanRoutesTest(unittest.TestCase):
 
         # ASSERT
         assert response.status_code == 422
+
+    def test_create_treatment_plan_blank_goal_returns_422(self) -> None:
+        """
+        Given the goal field contains only whitespace,
+        When POST /treatment-plan/42 is called,
+        Then 422 Unprocessable Entity is returned (goal_not_blank field_validator).
+        """
+        # PREPARE
+        cursor = _TreatmentPlanStubCursor(fetchone_rows=[])
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.post(
+            "/treatment-plan/42",
+            json={
+                "goal": "   ",
+                "start_date": "2026-05-01",
+                "end_date": "2026-07-01",
+                "exercises": [
+                    {
+                        "exercise_id": 1,
+                        "reps": 10,
+                        "num_sets": 3,
+                        "weight": 0.0,
+                        "time_duration": 30,
+                        "time_unit": "seconds",
+                    }
+                ],
+            },
+        )
+
+        # ASSERT
+        assert response.status_code == 422
+
+    def test_create_treatment_plan_equal_start_end_date_returns_422(self) -> None:
+        """
+        Given start_date equals end_date in the request body,
+        When POST /treatment-plan/42 is called,
+        Then 422 Unprocessable Entity is returned (end_date_after_start_date uses <=).
+        """
+        # PREPARE
+        cursor = _TreatmentPlanStubCursor(fetchone_rows=[])
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.post(
+            "/treatment-plan/42",
+            json={
+                "goal": "Restore range of motion",
+                "start_date": "2026-05-01",
+                "end_date": "2026-05-01",
+                "exercises": [
+                    {
+                        "exercise_id": 1,
+                        "reps": 10,
+                        "num_sets": 3,
+                        "weight": 0.0,
+                        "time_duration": 30,
+                        "time_unit": "seconds",
+                    }
+                ],
+            },
+        )
+
+        # ASSERT
+        assert response.status_code == 422
+
+    def test_get_exercises_without_visit_type_defaults_to_physiotherapist(
+        self,
+    ) -> None:
+        """
+        Given no visit_type query parameter is provided,
+        When GET /treatment-plan/exercises is called,
+        Then 200 is returned using the PHYSIOTHERAPIST default.
+        """
+        # PREPARE
+        cursor = _TreatmentPlanStubCursor(
+            fetchone_rows=[],
+            fetchall_rows=[{"exercise_id": 1, "exercise_name": "Curl"}],
+        )
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.get("/treatment-plan/exercises")
+
+        # ASSERT
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["exercise_id"] == 1
+
+    def test_get_fitness_plan_by_plan_id_returns_visit_type_fitness(self) -> None:
+        """
+        Given an active FITNESS plan exists for the plan_id,
+        When GET /treatment-plan/plan/{plan_id} is called,
+        Then 200 is returned and visit_type in the response body is 'FITNESS'.
+        """
+        # PREPARE
+        cursor = _TreatmentPlanStubCursor(
+            fetchone_rows=[
+                {
+                    "plan_id": 20,
+                    "session_id": 77,
+                    "medical_diagnosis": "Knee strengthening",
+                    "visit_type": "FITNESS",
+                    "goal": "Build lower body strength",
+                    "start_date": datetime.date(2026, 5, 1),
+                    "end_date": datetime.date(2026, 8, 1),
+                    "notes": None,
+                }
+            ],
+            fetchall_rows=[
+                {
+                    "exercise_id": 5,
+                    "exercise_name": "Wall Squats",
+                    "reps": 12,
+                    "num_sets": 3,
+                    "weight": None,
+                    "time_duration": 3,
+                    "time_unit": "Weekly",
+                    "description": None,
+                }
+            ],
+        )
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.get("/treatment-plan/plan/20")
+
+        # ASSERT
+        assert response.status_code == 200
+        body = response.json()
+        assert body["visit_type"] == "FITNESS"
+        assert body["plan_id"] == 20
+        assert len(body["exercises"]) == 1
+
+    def test_create_fitness_session_with_pt_exercise_returns_400(self) -> None:
+        """
+        Given a FITNESS session and an exercise that is only valid for PHYSIOTHERAPIST,
+        When POST /treatment-plan/77 is called,
+        Then 400 Bad Request is returned.
+
+        fetchone sequence:
+          1. get_treatment_plan_context → FITNESS context
+          2. plan_exists → None  (no plan)
+        fetchall: [] (exercise ID 1 is a PT exercise, not valid for FITNESS)
+        """
+        # PREPARE
+        cursor = _TreatmentPlanStubCursor(
+            fetchone_rows=[
+                {
+                    "session_id": 77,
+                    "medical_diagnosis": "Knee strengthening",
+                    "visit_type": "FITNESS",
+                },
+                None,
+            ],
+            fetchall_rows=[],
+        )
+
+        async def override_get_db():
+            yield cursor
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        # ACT
+        client = TestClient(app)
+        response = client.post(
+            "/treatment-plan/77",
+            json={
+                "goal": "Build lower body strength",
+                "start_date": "2026-05-01",
+                "end_date": "2026-08-01",
+                "exercises": [
+                    {
+                        "exercise_id": 1,
+                        "reps": 10,
+                        "num_sets": 3,
+                        "weight": 0.0,
+                        "time_duration": 30,
+                        "time_unit": "seconds",
+                    }
+                ],
+            },
+        )
+
+        # ASSERT
+        assert response.status_code == 400

--- a/server/tests/unit/dal/test_treatment_plan_repository.py
+++ b/server/tests/unit/dal/test_treatment_plan_repository.py
@@ -31,6 +31,7 @@ class TreatmentPlanRepositoryTest(unittest.TestCase):
             "plan_id": 6,
             "session_id": 103,
             "medical_diagnosis": "Shoulder Impingement",
+            "visit_type": "PHYSIOTHERAPIST",
             "goal": "Restore full range of motion",
             "start_date": datetime.date(2025, 1, 6),
             "end_date": datetime.date(2025, 3, 1),
@@ -51,6 +52,7 @@ class TreatmentPlanRepositoryTest(unittest.TestCase):
         assert result.plan_id == 6
         assert result.session_id == 103
         assert result.medical_diagnosis == "Shoulder Impingement"
+        assert result.visit_type == "PHYSIOTHERAPIST"
         assert result.goal == "Restore full range of motion"
         assert result.notes is None
         assert result.exercises == []
@@ -152,3 +154,225 @@ class TreatmentPlanRepositoryTest(unittest.TestCase):
 
         # ASSERT
         assert result == []
+
+    # ------------------------------------------------------------------ #
+    # plan_exists                                                          #
+    # ------------------------------------------------------------------ #
+
+    def test_plan_exists_returns_true_when_row_found(self) -> None:
+        """
+        Given the DB returns a plan row for the session_id,
+        When plan_exists is called,
+        Then True is returned.
+        """
+        # PREPARE
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+
+        # MOCK
+        expect(cursor, times=1).execute(query=ANY, args=ANY).thenReturn(
+            async_return(None)
+        )
+        expect(cursor, times=1).fetchone().thenReturn(async_return({"plan_id": 5}))
+
+        # ACT
+        result = asyncio.run(repo.plan_exists(42))
+
+        # ASSERT
+        assert result is True
+
+    def test_plan_exists_returns_false_when_no_row(self) -> None:
+        """
+        Given the DB returns no plan row for the session_id,
+        When plan_exists is called,
+        Then False is returned.
+        """
+        # PREPARE
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+
+        # MOCK
+        expect(cursor, times=1).execute(query=ANY, args=ANY).thenReturn(
+            async_return(None)
+        )
+        expect(cursor, times=1).fetchone().thenReturn(async_return(None))
+
+        # ACT
+        result = asyncio.run(repo.plan_exists(9999))
+
+        # ASSERT
+        assert result is False
+
+    # ------------------------------------------------------------------ #
+    # get_valid_exercise_ids                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_get_valid_exercise_ids_returns_empty_for_empty_input(self) -> None:
+        """
+        Given an empty exercise_ids list is provided,
+        When get_valid_exercise_ids is called,
+        Then [] is returned immediately without querying the DB.
+        """
+        # PREPARE — no cursor expectations: any cursor call would raise
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+
+        # ACT
+        result = asyncio.run(repo.get_valid_exercise_ids([], "PHYSIOTHERAPIST"))
+
+        # ASSERT
+        assert result == []
+
+    def test_get_valid_exercise_ids_returns_all_ids_when_all_match(self) -> None:
+        """
+        Given all requested exercise IDs exist and match the visit_type,
+        When get_valid_exercise_ids is called,
+        Then all IDs are returned.
+        """
+        # PREPARE
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+
+        # MOCK
+        expect(cursor, times=1).execute(query=ANY, args=ANY).thenReturn(
+            async_return(None)
+        )
+        expect(cursor, times=1).fetchall().thenReturn(
+            async_return([{"exercise_id": 1}, {"exercise_id": 2}])
+        )
+
+        # ACT
+        result = asyncio.run(repo.get_valid_exercise_ids([1, 2], "PHYSIOTHERAPIST"))
+
+        # ASSERT
+        assert result == [1, 2]
+
+    def test_get_valid_exercise_ids_returns_empty_when_none_match_visit_type(
+        self,
+    ) -> None:
+        """
+        Given the requested exercise IDs belong to a different visit_type,
+        When get_valid_exercise_ids is called with the wrong visit_type,
+        Then an empty list is returned.
+        """
+        # PREPARE
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+
+        # MOCK — DB returns nothing because IDs 5,6 are FITNESS, not PHYSIOTHERAPIST
+        expect(cursor, times=1).execute(query=ANY, args=ANY).thenReturn(
+            async_return(None)
+        )
+        expect(cursor, times=1).fetchall().thenReturn(async_return([]))
+
+        # ACT
+        result = asyncio.run(repo.get_valid_exercise_ids([5, 6], "PHYSIOTHERAPIST"))
+
+        # ASSERT
+        assert result == []
+
+    # ------------------------------------------------------------------ #
+    # get_exercises_by_visit_type — FITNESS branch                        #
+    # ------------------------------------------------------------------ #
+
+    def test_get_exercises_by_visit_type_returns_fitness_list(self) -> None:
+        """
+        Given the DB returns exercise rows with visit_type FITNESS,
+        When get_exercises_by_visit_type is called with 'FITNESS',
+        Then a list of PhysiotherapyExerciseItem instances is returned.
+        """
+        # PREPARE
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+        rows = [
+            {"exercise_id": 5, "exercise_name": "Wall Squats"},
+            {"exercise_id": 6, "exercise_name": "Plank"},
+        ]
+
+        # MOCK
+        expect(cursor, times=1).execute(query=ANY, args=ANY).thenReturn(
+            async_return(None)
+        )
+        expect(cursor, times=1).fetchall().thenReturn(async_return(rows))
+
+        # ACT
+        result = asyncio.run(repo.get_exercises_by_visit_type("FITNESS"))
+
+        # ASSERT
+        assert len(result) == 2
+        assert result[0].exercise_id == 5
+        assert result[0].exercise_name == "Wall Squats"
+        assert result[1].exercise_id == 6
+
+    # ------------------------------------------------------------------ #
+    # get_treatment_plan_context — FITNESS branch                         #
+    # ------------------------------------------------------------------ #
+
+    def test_get_treatment_plan_context_returns_fitness_context(self) -> None:
+        """
+        Given the DB returns a row with visit_type FITNESS,
+        When get_treatment_plan_context is called,
+        Then a TreatmentPlanContext with visit_type FITNESS is returned.
+        """
+        # PREPARE
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+        row = {
+            "session_id": 55,
+            "medical_diagnosis": "Lower back strain",
+            "visit_type": "FITNESS",
+        }
+
+        # MOCK
+        expect(cursor, times=1).execute(query=ANY, args=ANY).thenReturn(
+            async_return(None)
+        )
+        expect(cursor, times=1).fetchone().thenReturn(async_return(row))
+
+        # ACT
+        result = asyncio.run(repo.get_treatment_plan_context(55))
+
+        # ASSERT
+        assert result is not None
+        assert result.session_id == 55
+        assert result.visit_type == "FITNESS"
+        assert result.medical_diagnosis == "Lower back strain"
+
+    # ------------------------------------------------------------------ #
+    # get_treatment_plan_by_plan_id — FITNESS visit_type                  #
+    # ------------------------------------------------------------------ #
+
+    def test_get_treatment_plan_by_plan_id_returns_fitness_visit_type(self) -> None:
+        """
+        Given the DB returns a plan row where the session has visit_type FITNESS,
+        When get_treatment_plan_by_plan_id is called,
+        Then the returned TreatmentPlanDetailsResponse has visit_type FITNESS.
+        """
+        # PREPARE
+        cursor = mock()
+        repo = TreatmentPlanRepository(db=cursor)
+        row = {
+            "plan_id": 20,
+            "session_id": 77,
+            "medical_diagnosis": "Knee strengthening",
+            "visit_type": "FITNESS",
+            "goal": "Build lower body strength",
+            "start_date": datetime.date(2026, 5, 1),
+            "end_date": datetime.date(2026, 8, 1),
+            "notes": None,
+        }
+
+        # MOCK
+        expect(cursor, times=1).execute(query=ANY, args=ANY).thenReturn(
+            async_return(None)
+        )
+        expect(cursor, times=1).fetchone().thenReturn(async_return(row))
+
+        # ACT
+        result = asyncio.run(repo.get_treatment_plan_by_plan_id(20))
+
+        # ASSERT
+        assert result is not None
+        assert result.visit_type == "FITNESS"
+        assert result.plan_id == 20
+        assert result.exercises == []

--- a/server/tests/unit/services/test_treatment_plan_services.py
+++ b/server/tests/unit/services/test_treatment_plan_services.py
@@ -23,6 +23,7 @@ def _make_treatment_plan_details(**overrides) -> TreatmentPlanDetailsResponse:
         "plan_id": 6,
         "session_id": 103,
         "medical_diagnosis": "Shoulder Impingement",
+        "visit_type": "PHYSIOTHERAPIST",
         "goal": "Restore full range of motion",
         "start_date": datetime.date(2025, 1, 6),
         "end_date": datetime.date(2025, 3, 1),
@@ -130,11 +131,11 @@ class TreatmentPlanServicesTest(unittest.TestCase):
             asyncio.run(service.get_treatment_plan_context(999))
         self.assertEqual(ctx.exception.status_code, 404)
 
-    def test_get_context_non_physiotherapist_raises_400(self) -> None:
+    def test_get_context_fitness_session_returns_context(self) -> None:
         """
-        Given the repository returns a FITNESS session context,
+        Given the repository returns a FITNESS context for the session,
         When get_treatment_plan_context is called,
-        Then an HTTP 400 Bad Request exception is raised.
+        Then the TreatmentPlanContext with visit_type FITNESS is returned (no 400 error).
         """
         # PREPARE
         repo = mock(TreatmentPlanRepository)
@@ -144,19 +145,21 @@ class TreatmentPlanServicesTest(unittest.TestCase):
         # MOCK
         expect(repo, times=1).get_treatment_plan_context(42).thenReturn(context)
 
-        # ACT / ASSERT
-        with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(service.get_treatment_plan_context(42))
-        self.assertEqual(ctx.exception.status_code, 400)
+        # ACT
+        result = asyncio.run(service.get_treatment_plan_context(42))
+
+        # ASSERT
+        self.assertEqual(result.visit_type, "FITNESS")
+        self.assertEqual(result.session_id, 42)
 
     # ------------------------------------------------------------------ #
-    # get_physiotherapy_exercises                                          #
+    # get_exercises                                                        #
     # ------------------------------------------------------------------ #
 
-    def test_get_exercises_returns_list(self) -> None:
+    def test_get_exercises_returns_physiotherapist_list(self) -> None:
         """
-        Given the repository returns two exercise items,
-        When get_physiotherapy_exercises is called,
+        Given the repository returns two exercise items for PHYSIOTHERAPIST,
+        When get_exercises is called with visit_type PHYSIOTHERAPIST,
         Then a list of two PhysiotherapyExerciseItem instances is returned.
         """
         # PREPARE
@@ -168,15 +171,44 @@ class TreatmentPlanServicesTest(unittest.TestCase):
         ]
 
         # MOCK
-        expect(repo, times=1).get_physiotherapy_exercises().thenReturn(exercises)
+        expect(repo, times=1).get_exercises_by_visit_type(
+            "PHYSIOTHERAPIST"
+        ).thenReturn(exercises)
 
         # ACT
-        result = asyncio.run(service.get_physiotherapy_exercises())
+        result = asyncio.run(service.get_exercises("PHYSIOTHERAPIST"))
 
         # ASSERT
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].exercise_name, "Curl")
         self.assertEqual(result[1].exercise_id, 2)
+
+    def test_get_fitness_exercises_returns_list(self) -> None:
+        """
+        Given the repository returns two exercise items for FITNESS,
+        When get_exercises is called with visit_type FITNESS,
+        Then a list of two PhysiotherapyExerciseItem instances is returned.
+        """
+        # PREPARE
+        repo = mock(TreatmentPlanRepository)
+        service = TreatmentPlanServices(repository=repo)
+        exercises = [
+            PhysiotherapyExerciseItem(exercise_id=5, exercise_name="Wall Squats"),
+            PhysiotherapyExerciseItem(exercise_id=6, exercise_name="Plank"),
+        ]
+
+        # MOCK
+        expect(repo, times=1).get_exercises_by_visit_type("FITNESS").thenReturn(
+            exercises
+        )
+
+        # ACT
+        result = asyncio.run(service.get_exercises("FITNESS"))
+
+        # ASSERT
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].exercise_name, "Wall Squats")
+        self.assertEqual(result[1].exercise_id, 6)
 
     # ------------------------------------------------------------------ #
     # create_treatment_plan                                                #
@@ -184,7 +216,7 @@ class TreatmentPlanServicesTest(unittest.TestCase):
 
     def test_create_plan_success(self) -> None:
         """
-        Given a valid session, no existing plan, and all exercises are PHYSIOTHERAPIST,
+        Given a valid PHYSIOTHERAPIST session, no existing plan, and valid exercises,
         When create_treatment_plan is called,
         Then the repository creates the plan and returns CreateTreatmentPlanResponse.
         """
@@ -198,7 +230,9 @@ class TreatmentPlanServicesTest(unittest.TestCase):
         # MOCK
         expect(repo, times=1).get_treatment_plan_context(42).thenReturn(context)
         expect(repo, times=1).plan_exists(42).thenReturn(False)
-        expect(repo, times=1).get_valid_physiotherapy_exercise_ids([1]).thenReturn([1])
+        expect(repo, times=1).get_valid_exercise_ids([1], "PHYSIOTHERAPIST").thenReturn(
+            [1]
+        )
         expect(repo, times=1).create_treatment_plan(42, request).thenReturn(response)
 
         # ACT
@@ -206,6 +240,35 @@ class TreatmentPlanServicesTest(unittest.TestCase):
 
         # ASSERT
         self.assertEqual(result.plan_id, 10)
+        self.assertEqual(result.session_id, 42)
+
+    def test_create_fitness_plan_success(self) -> None:
+        """
+        Given a valid FITNESS session, no existing plan, and valid FITNESS exercises,
+        When create_treatment_plan is called,
+        Then the repository creates the plan and returns CreateTreatmentPlanResponse.
+        """
+        # PREPARE
+        repo = mock(TreatmentPlanRepository)
+        service = TreatmentPlanServices(repository=repo)
+        context = _make_physio_context(visit_type="FITNESS", medical_diagnosis="Knee strengthening")
+        request = _make_create_request(
+            goal="Build lower body strength",
+            exercises=[_make_exercise_request(exercise_id=5)],
+        )
+        response = CreateTreatmentPlanResponse(plan_id=20, session_id=42)
+
+        # MOCK
+        expect(repo, times=1).get_treatment_plan_context(42).thenReturn(context)
+        expect(repo, times=1).plan_exists(42).thenReturn(False)
+        expect(repo, times=1).get_valid_exercise_ids([5], "FITNESS").thenReturn([5])
+        expect(repo, times=1).create_treatment_plan(42, request).thenReturn(response)
+
+        # ACT
+        result = asyncio.run(service.create_treatment_plan(42, request))
+
+        # ASSERT
+        self.assertEqual(result.plan_id, 20)
         self.assertEqual(result.session_id, 42)
 
     def test_create_plan_session_not_found_raises_404(self) -> None:
@@ -227,26 +290,6 @@ class TreatmentPlanServicesTest(unittest.TestCase):
             asyncio.run(service.create_treatment_plan(42, request))
         self.assertEqual(ctx.exception.status_code, 404)
 
-    def test_create_plan_non_physiotherapist_raises_400(self) -> None:
-        """
-        Given the session has visit_type FITNESS,
-        When create_treatment_plan is called,
-        Then an HTTP 400 Bad Request exception is raised.
-        """
-        # PREPARE
-        repo = mock(TreatmentPlanRepository)
-        service = TreatmentPlanServices(repository=repo)
-        context = _make_physio_context(visit_type="FITNESS")
-        request = _make_create_request()
-
-        # MOCK
-        expect(repo, times=1).get_treatment_plan_context(42).thenReturn(context)
-
-        # ACT / ASSERT
-        with self.assertRaises(HTTPException) as ctx:
-            asyncio.run(service.create_treatment_plan(42, request))
-        self.assertEqual(ctx.exception.status_code, 400)
-
     def test_create_plan_already_exists_raises_409(self) -> None:
         """
         Given a treatment plan already exists for the session,
@@ -267,6 +310,36 @@ class TreatmentPlanServicesTest(unittest.TestCase):
         with self.assertRaises(HTTPException) as ctx:
             asyncio.run(service.create_treatment_plan(42, request))
         self.assertEqual(ctx.exception.status_code, 409)
+
+    def test_create_plan_mismatched_exercise_type_raises_400(self) -> None:
+        """
+        Given a PHYSIOTHERAPIST session and one exercise whose visit_type
+        does not match (i.e. it is not in the valid PHYSIOTHERAPIST set),
+        When create_treatment_plan is called,
+        Then an HTTP 400 Bad Request exception is raised.
+        """
+        # PREPARE
+        repo = mock(TreatmentPlanRepository)
+        service = TreatmentPlanServices(repository=repo)
+        context = _make_physio_context()
+        request = _make_create_request(
+            exercises=[
+                _make_exercise_request(exercise_id=1),
+                _make_exercise_request(exercise_id=99),
+            ]
+        )
+
+        # MOCK
+        expect(repo, times=1).get_treatment_plan_context(42).thenReturn(context)
+        expect(repo, times=1).plan_exists(42).thenReturn(False)
+        expect(repo, times=1).get_valid_exercise_ids(
+            [1, 99], "PHYSIOTHERAPIST"
+        ).thenReturn([1])
+
+        # ACT / ASSERT
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(service.create_treatment_plan(42, request))
+        self.assertEqual(ctx.exception.status_code, 400)
 
     # ------------------------------------------------------------------ #
     # get_treatment_plan_by_plan_id                                        #
@@ -294,6 +367,7 @@ class TreatmentPlanServicesTest(unittest.TestCase):
         # ASSERT
         self.assertEqual(result.plan_id, 6)
         self.assertEqual(result.medical_diagnosis, "Shoulder Impingement")
+        self.assertEqual(result.visit_type, "PHYSIOTHERAPIST")
         self.assertEqual(len(result.exercises), 1)
         self.assertEqual(result.exercises[0].exercise_name, "Wall Squats")
 
@@ -315,9 +389,67 @@ class TreatmentPlanServicesTest(unittest.TestCase):
             asyncio.run(service.get_treatment_plan_by_plan_id(9999))
         self.assertEqual(ctx.exception.status_code, 404)
 
-    def test_create_plan_fitness_exercise_raises_400(self) -> None:
+    def test_get_treatment_plan_by_plan_id_returns_fitness_plan_with_correct_visit_type(
+        self,
+    ) -> None:
         """
-        Given one requested exercise is not in the valid PHYSIOTHERAPIST exercise set,
+        Given the repository returns a FITNESS plan with one exercise,
+        When get_treatment_plan_by_plan_id is called,
+        Then the returned response has visit_type FITNESS and exercises attached.
+        """
+        # PREPARE
+        repo = mock(TreatmentPlanRepository)
+        service = TreatmentPlanServices(repository=repo)
+        fitness_plan = _make_treatment_plan_details(
+            plan_id=20,
+            session_id=77,
+            visit_type="FITNESS",
+            medical_diagnosis="Knee strengthening",
+        )
+        exercises = [_make_plan_exercise_item(exercise_id=5, exercise_name="Wall Squats")]
+
+        # MOCK
+        expect(repo, times=1).get_treatment_plan_by_plan_id(20).thenReturn(fitness_plan)
+        expect(repo, times=1).get_exercises_by_plan(20, 77).thenReturn(exercises)
+
+        # ACT
+        result = asyncio.run(service.get_treatment_plan_by_plan_id(20))
+
+        # ASSERT
+        self.assertEqual(result.visit_type, "FITNESS")
+        self.assertEqual(result.plan_id, 20)
+        self.assertEqual(len(result.exercises), 1)
+        self.assertEqual(result.exercises[0].exercise_name, "Wall Squats")
+
+    # ------------------------------------------------------------------ #
+    # create_treatment_plan — additional cross-type and mismatch cases    #
+    # ------------------------------------------------------------------ #
+
+    def test_create_plan_fitness_session_with_pt_exercise_raises_400(self) -> None:
+        """
+        Given a FITNESS session and an exercise that belongs to PHYSIOTHERAPIST,
+        When create_treatment_plan is called,
+        Then an HTTP 400 Bad Request exception is raised.
+        """
+        # PREPARE
+        repo = mock(TreatmentPlanRepository)
+        service = TreatmentPlanServices(repository=repo)
+        context = _make_physio_context(visit_type="FITNESS", medical_diagnosis="Knee strengthening")
+        request = _make_create_request(exercises=[_make_exercise_request(exercise_id=1)])
+
+        # MOCK — exercise ID 1 is a PT exercise; not valid for FITNESS
+        expect(repo, times=1).get_treatment_plan_context(42).thenReturn(context)
+        expect(repo, times=1).plan_exists(42).thenReturn(False)
+        expect(repo, times=1).get_valid_exercise_ids([1], "FITNESS").thenReturn([])
+
+        # ACT / ASSERT
+        with self.assertRaises(HTTPException) as ctx:
+            asyncio.run(service.create_treatment_plan(42, request))
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_create_plan_with_partial_exercise_mismatch_raises_400(self) -> None:
+        """
+        Given a PHYSIOTHERAPIST session and three exercises where one is invalid,
         When create_treatment_plan is called,
         Then an HTTP 400 Bad Request exception is raised.
         """
@@ -328,16 +460,17 @@ class TreatmentPlanServicesTest(unittest.TestCase):
         request = _make_create_request(
             exercises=[
                 _make_exercise_request(exercise_id=1),
+                _make_exercise_request(exercise_id=2),
                 _make_exercise_request(exercise_id=99),
             ]
         )
 
-        # MOCK
+        # MOCK — IDs 1 and 2 are valid; 99 is not in the PHYSIOTHERAPIST set
         expect(repo, times=1).get_treatment_plan_context(42).thenReturn(context)
         expect(repo, times=1).plan_exists(42).thenReturn(False)
-        expect(repo, times=1).get_valid_physiotherapy_exercise_ids(
-            [1, 99]
-        ).thenReturn([1])
+        expect(repo, times=1).get_valid_exercise_ids(
+            [1, 2, 99], "PHYSIOTHERAPIST"
+        ).thenReturn([1, 2])
 
         # ACT / ASSERT
         with self.assertRaises(HTTPException) as ctx:


### PR DESCRIPTION
- Updated VisitSummaryDetail component to use visit_type for plan actions.
- Modified API response models to include visit_type for treatment plans.
- Refactored treatment_plan_routes to accept visit_type as a query parameter.
- Adjusted treatment_plan_repository to fetch exercises based on visit_type.
- Enhanced treatment_plan_services to handle FITNESS sessions and validate exercises accordingly.
- Updated unit tests to cover new FITNESS functionality and ensure proper handling of exercise types.