### PR TITLE
feat: add two-mode AI search, conversation history, and source verifi…

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@tanstack/react-form": "^1.28.5",
@@ -489,6 +490,44 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -658,11 +697,415 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -680,6 +1123,249 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -719,6 +1405,78 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
@@ -736,6 +1494,133 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
@@ -1640,6 +2525,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2062,6 +2959,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2615,6 +3518,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -3835,6 +4747,53 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
@@ -3871,6 +4830,28 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -4268,9 +5249,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4368,6 +5347,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc -p tsconfig.app.json --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-form": "^1.28.5",

--- a/client/src/components/ui/dropdown-menu.tsx
+++ b/client/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { cn } from '@/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[10rem] overflow-hidden rounded-xl border border-gray-200 bg-white p-1 shadow-lg',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-pointer select-none items-center rounded-lg px-2 py-1.5 text-sm outline-none',
+      'transition-colors focus:bg-accent focus:text-accent-foreground',
+      'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      className,
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+export { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem }

--- a/client/src/hooks/useAiSearchMutation.ts
+++ b/client/src/hooks/useAiSearchMutation.ts
@@ -3,12 +3,17 @@ import { useSetAtom, useAtomValue } from 'jotai'
 import { searchResultsAtom } from '@/store/aiSearchAtom'
 import { authAtom } from '@/store/authAtom'
 import apiClient from '@/lib/apiClient'
-import type { AiExchange, AiConversation } from '@/types'
+import type { AiExchange, AiConversation, SearchMode } from '@/types'
 
 interface AiSearchApiResponse {
   query_id: number
   summary: string
   sources: AiExchange['sources']
+}
+
+interface AiSearchMutationArgs {
+  query: string
+  searchMode: SearchMode
 }
 
 export function useAiSearchMutation() {
@@ -18,7 +23,7 @@ export function useAiSearchMutation() {
   const auth = useAtomValue(authAtom)
 
   return useMutation({
-    mutationFn: async (queryContent: string): Promise<AiConversation> => {
+    mutationFn: async ({ query: queryContent, searchMode }: AiSearchMutationArgs): Promise<AiConversation> => {
       const history = (searchResults ?? []).map((ex) => ({
         query: ex.query_content,
         answer: ex.ai_summary,
@@ -28,13 +33,19 @@ export function useAiSearchMutation() {
         user_id: auth?.id,
         user_role: auth?.role,
         conversation_history: history,
+        search_mode: searchMode,
       })
       const { query_id, summary, sources } = response.data
+      const sortedSources = [...sources].sort((a, b) => {
+        const aV = a.physio_verification_count > 0 || a.trainer_verification_count > 0 ? 1 : 0
+        const bV = b.physio_verification_count > 0 || b.trainer_verification_count > 0 ? 1 : 0
+        return bV - aV
+      })
       const exchange: AiExchange = {
         query_id,
         query_content: queryContent,
         ai_summary: summary,
-        sources,
+        sources: sortedSources,
       }
       return [exchange]
     },

--- a/client/src/pages/ai-search/AiSearchPage.tsx
+++ b/client/src/pages/ai-search/AiSearchPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, Info } from 'lucide-react'
 import { useAtom, useAtomValue } from 'jotai'
 import { authAtom } from '@/store/authAtom'
-import { currentQueryAtom, searchResultsAtom } from '@/store/aiSearchAtom'
+import { currentQueryAtom, searchResultsAtom, searchModeAtom } from '@/store/aiSearchAtom'
 import { useAiSearchMutation } from '@/hooks/useAiSearchMutation'
 import { resolveSearchError } from '@/lib/aiSearchUtils'
 import BackButton from '@/components/ui/BackButton'
@@ -19,6 +19,7 @@ export default function AiSearchPage() {
   const auth = useAtomValue(authAtom)
   const [currentQuery, setCurrentQuery] = useAtom(currentQueryAtom)
   const [searchResults, setSearchResults] = useAtom(searchResultsAtom)
+  const searchMode = useAtomValue(searchModeAtom)
   const searchMutation = useAiSearchMutation()
   const navigate = useNavigate()
 
@@ -64,7 +65,7 @@ export default function AiSearchPage() {
                 placeholder="Ask about your recovery, exercises, or diagnosis…"
                 value={currentQuery}
                 onValueChange={setCurrentQuery}
-                onSubmit={(text) => { setCurrentQuery(text); searchMutation.mutate(text) }}
+                onSubmit={(text) => { setCurrentQuery(text); searchMutation.mutate({ query: text, searchMode }) }}
                 isPending={searchMutation.isPending}
                 isError={searchMutation.isError}
                 errorMessage={resolveSearchError(searchMutation.error)}
@@ -110,7 +111,7 @@ export default function AiSearchPage() {
                 float above all content regardless of scroll position */}
             {createPortal(
               <FollowUpBar
-                onSubmit={(text: string) => { setCurrentQuery(text); searchMutation.mutate(text) }}
+                onSubmit={(text: string) => { setCurrentQuery(text); searchMutation.mutate({ query: text, searchMode }) }}
                 isPending={searchMutation.isPending}
                 isError={searchMutation.isError}
                 errorMessage={resolveSearchError(searchMutation.error)}

--- a/client/src/pages/ai-search/SavedContentPage.css
+++ b/client/src/pages/ai-search/SavedContentPage.css
@@ -6,14 +6,18 @@
 .ais-saved__main {
   max-width: 48rem;
   margin: 0 auto;
-  padding: 2rem 1rem 4rem;
+  padding: 1.5rem 1rem 4rem;
 }
 
-/* ─── Page title row (back button + h1) ─── */
+/* ─── Back button row (outside main, matches ai-search positioning) ─── */
+.ais-saved__back-row {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 0 0;
+}
+
+/* ─── Page title ─── */
 .ais-saved__page-title {
-  display: flex;
-  align-items: center;
-  gap: 0.875rem;
   margin-bottom: 0.75rem;
 }
 

--- a/client/src/pages/ai-search/SavedContentPage.tsx
+++ b/client/src/pages/ai-search/SavedContentPage.tsx
@@ -68,10 +68,14 @@ export default function SavedContentPage() {
     <div className="ais-saved pt-16">
       <TopNav />
 
+      {/* ─── Back ─── */}
+      <div className="ais-saved__back-row">
+        <BackButton onClick={() => navigate(HOME_ROUTE[userRole])} aria-label="Back to home" />
+      </div>
+
       <main className="ais-saved__main">
         {/* ─── Page title ─── */}
         <div className="ais-saved__page-title">
-          <BackButton onClick={() => navigate(HOME_ROUTE[userRole])} aria-label="Back to home" />
           <h1 className="ais-saved__title">My Saved Content</h1>
         </div>
 

--- a/client/src/pages/ai-search/components/ExchangeBlock.tsx
+++ b/client/src/pages/ai-search/components/ExchangeBlock.tsx
@@ -18,11 +18,7 @@ interface ExchangeBlockProps {
 function applyFilter(sources: SourceCardType[], filter: FilterKey): SourceCardType[] {
   if (filter === 'verified') return sources.filter((s) => s.physio_verification_count > 0 || s.trainer_verification_count > 0)
   if (filter === 'unverified') return sources.filter((s) => s.physio_verification_count === 0 && s.trainer_verification_count === 0)
-  return [...sources].sort((a, b) => {
-    const aVerified = a.physio_verification_count > 0 || a.trainer_verification_count > 0 ? 1 : 0
-    const bVerified = b.physio_verification_count > 0 || b.trainer_verification_count > 0 ? 1 : 0
-    return bVerified - aVerified
-  })
+  return [...sources]
 }
 
 export default function ExchangeBlock({

--- a/client/src/pages/ai-search/components/FollowUpBar.tsx
+++ b/client/src/pages/ai-search/components/FollowUpBar.tsx
@@ -1,7 +1,53 @@
 import { useState, useRef, useEffect } from 'react'
-import { Send, Loader2 } from 'lucide-react'
+import { Send, Loader2, ChevronDown, Zap, Brain, Check } from 'lucide-react'
+import { useAtom } from 'jotai'
 import { Button } from '@/components/ui/button'
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-menu'
+import { searchModeAtom } from '@/store/aiSearchAtom'
+import type { SearchMode } from '@/types'
 import { cn } from '@/lib/utils'
+
+const MODES: { value: SearchMode; label: string; icon: React.ReactNode }[] = [
+  { value: 'instant', label: 'Instant', icon: <Zap size={14} /> },
+  { value: 'thinking', label: 'Thinking', icon: <Brain size={14} /> },
+]
+
+function ModeToggle() {
+  const [mode, setMode] = useAtom(searchModeAtom)
+  const [open, setOpen] = useState(false)
+  const current = MODES.find((m) => m.value === mode)!
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 rounded-full border border-gray-200 bg-muted px-3 text-xs font-medium text-gray-700 hover:bg-gray-100 transition-colors h-9 whitespace-nowrap"
+        >
+          <span className="text-[var(--color-primary)]">{current.icon}</span>
+          <span className="hidden sm:inline">{current.label}</span>
+          <ChevronDown
+            size={12}
+            className={cn('text-gray-400 transition-transform duration-200', open && 'rotate-180')}
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-44">
+        {MODES.map(({ value, label, icon }) => (
+          <DropdownMenuItem
+            key={value}
+            onSelect={() => setMode(value)}
+            className={cn('gap-2', value === mode && 'bg-indigo-50')}
+          >
+            <span className="text-[var(--color-primary)]">{icon}</span>
+            <span className="flex-1 font-semibold">{label}</span>
+            {value === mode && <Check size={13} className="text-indigo-500 shrink-0" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
 
 // Supports two variants:
 //   'inline'  — used in the idle state, sits in the normal document flow
@@ -95,7 +141,7 @@ export default function FollowUpBar({
     <div ref={containerRef} className={cn('ais-followup-bar', variant === 'inline' && 'ais-followup-bar--inline')}>
       <div className="flex flex-col gap-1">
         {/* Error is rendered outside the flex row so it doesn't affect button height */}
-        <form onSubmit={handleSubmit} className="flex gap-2 items-stretch">
+        <form onSubmit={handleSubmit} className="flex gap-2 items-end">
           <textarea
             ref={textareaRef}
             value={text}
@@ -105,11 +151,11 @@ export default function FollowUpBar({
             rows={1}
             className="flex-1 resize-none rounded-xl border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400 bg-gray-50 placeholder-gray-400"
           />
-          {/* self-stretch makes the button exactly as tall as the textarea */}
+          <ModeToggle />
           <Button
             type="submit"
             disabled={isPending || !text.trim()}
-            className="rounded-xl self-stretch bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary-hover)] shadow-none disabled:cursor-not-allowed disabled:pointer-events-auto"
+            className="rounded-xl bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary-hover)] shadow-none disabled:cursor-not-allowed disabled:pointer-events-auto"
           >
             {isPending ? (
               <><Loader2 size={16} className="animate-spin" />Asking…</>

--- a/client/src/pages/profile/ProfilePage.css
+++ b/client/src/pages/profile/ProfilePage.css
@@ -8,11 +8,16 @@
   flex-direction: column;
 }
 
+/* ── Back button row ── */
+.pp-back-row {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 0 0;
+}
+
 /* ── Page title ── */
 .pp-title-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
   margin-bottom: 18px;
 }
 

--- a/client/src/pages/profile/ProfilePage.tsx
+++ b/client/src/pages/profile/ProfilePage.tsx
@@ -30,9 +30,12 @@ export default function ProfilePage() {
     <div className="pp-page pt-16">
       <TopNav />
 
+      <div className="pp-back-row">
+        <BackButton onClick={handleBack} />
+      </div>
+
       <main className="pp-main">
         <div className="pp-title-row max-w-2xl mx-auto">
-          <BackButton onClick={handleBack} />
           <h1 className="pp-title">My Profile</h1>
         </div>
 

--- a/client/src/store/aiSearchAtom.ts
+++ b/client/src/store/aiSearchAtom.ts
@@ -1,8 +1,11 @@
 import { atom } from 'jotai'
-import type { AiConversation } from '@/types'
+import type { AiConversation, SearchMode } from '@/types'
 
 // text currently in the search textarea (for chip pre-fill)
 export const currentQueryAtom = atom<string>('')
 
 // accumulated conversation — array of exchanges; null when no search has run
 export const searchResultsAtom = atom<AiConversation | null>(null)
+
+// selected search depth mode — persists across idle/results transitions
+export const searchModeAtom = atom<SearchMode>('instant')

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -160,6 +160,8 @@ export interface PatientDetails extends Patient {
 
 // ── AI Search domain types ────────────────────────────────────────────────────
 
+export type SearchMode = 'instant' | 'thinking'
+
 export type ContentType = 'Article' | 'Clinical Guideline' | 'Exercise Guide' | 'Video'
 
 export interface AiQuery {

--- a/server/app/models/ai_search/ai_search.py
+++ b/server/app/models/ai_search/ai_search.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -17,6 +18,7 @@ class AiSearchRequest(BaseModel):
     user_id: str
     user_role: str
     conversation_history: list[HistoryExchange] | None = None
+    search_mode: Literal["instant", "thinking"] = "instant"
 
 
 class SourceCard(BaseModel):

--- a/server/app/services/ai_search_services.py
+++ b/server/app/services/ai_search_services.py
@@ -49,7 +49,7 @@ async def _build_raw_sources(json_sources: list[dict]) -> list[dict]:
     Returns:
         Source dicts with "url" replaced by the fully resolved destination URL.
     """
-    resolved_urls = await _resolve_grounding_urls(
+    resolved_urls = await resolve_grounding_urls(
         [s.get("url", "") for s in json_sources]
     )
     return [
@@ -84,7 +84,7 @@ async def _resolve_url(client: httpx.AsyncClient, url: str) -> str:
         return ""
 
 
-async def _resolve_grounding_urls(urls: list[str]) -> list[str]:
+async def resolve_grounding_urls(urls: list[str]) -> list[str]:
     """Resolve all grounding URLs in parallel, following Vertex AI redirects.
 
     Args:

--- a/server/app/services/ai_search_services.py
+++ b/server/app/services/ai_search_services.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import re
 
+import httpx
+
 from fastapi import HTTPException, status
 from google import genai
 
@@ -17,27 +19,83 @@ from app.models.ai_search.ai_search import (
     VerifyContentRequest,
 )
 
-_GEMINI_SYSTEM_INSTRUCTION = (
+_VERTEX_REDIRECT_PREFIX = "vertexaisearch.cloud.google.com/grounding-api-redirect/"
+
+_GEMINI_SYSTEM_INSTRUCTION_TEMPLATE = (
     "You are a rehabilitation and physiotherapy expert. "
-    "Use the Google Search tool to find current, publicly accessible sources. "
-    "Strongly prefer well-known, authoritative domains with stable, long-lived URLs — "
-    "for example: pubmed.ncbi.nlm.nih.gov, www.nhs.uk, www.mayoclinic.org, "
-    "www.physio-pedia.com, www.webmd.com, www.healthline.com, www.spine-health.com, "
-    "www.orthoinfo.aaos.org, www.cochrane.org, or official hospital/university sites. "
-    "Avoid deep article paths on small or obscure websites that are likely to go dead. "
-    "Only include the real, direct URL of the source webpage — for example "
-    "'https://www.physio-pedia.com/Rotator_Cuff'. "
-    "NEVER include vertexaisearch.cloud.google.com redirect URLs or any other "
-    "tracking/redirect URLs. "
-    "Do not invent or recall URLs from memory — only use URLs directly returned by Google Search. "
-    "Given a user query, respond ONLY with a valid JSON object in this exact shape: "
-    '{"summary": "<2-3 sentence plain-language answer>", '
-    '"sources": [{"title": "<source title>", "url": "<full direct URL>", '
+    "Use Google Search to find current, accessible sources. "
+    "Prefer authoritative medical domains (e.g. pubmed, NHS, Mayo Clinic, Physio-Pedia, Cochrane). "
+    "Respond ONLY with valid JSON in this exact shape — no markdown, no extra text: "
+    '{{"summary": "<2-3 sentence answer>", '
+    '"sources": [{{"title": "<title>", '
+    '"url": "<exact url of this source>", '
     '"description": "<1-2 sentence description>", '
-    '"content_type": "<one of: Article, Clinical Guideline, Exercise Guide, Video>"}]}. '
-    "Return 3-5 sources. "
-    "Do not wrap the JSON in markdown code blocks. Do not include any text outside the JSON."
+    '"content_type": "<Article|Clinical Guideline|Exercise Guide|Video>"}}]}}. '
+    "You MUST return exactly {max_sources} sources."
 )
+
+
+def _build_system_instruction(max_sources: str) -> str:
+    """Inject the source count into the system instruction template."""
+    return _GEMINI_SYSTEM_INSTRUCTION_TEMPLATE.format(max_sources=max_sources)
+
+
+async def _build_raw_sources(json_sources: list[dict]) -> list[dict]:
+    """Pair each source dict with its redirect-resolved URL.
+
+    Args:
+        json_sources: Source dicts from Gemini JSON, each containing a "url" key.
+
+    Returns:
+        Source dicts with "url" replaced by the fully resolved destination URL.
+    """
+    resolved_urls = await _resolve_grounding_urls(
+        [s.get("url", "") for s in json_sources]
+    )
+    return [
+        {**src, "url": resolved_url}
+        for src, resolved_url in zip(json_sources, resolved_urls)
+        if resolved_url
+    ]
+
+
+async def _resolve_url(client: httpx.AsyncClient, url: str) -> str:
+    """Follow a Vertex AI redirect to its final destination URL.
+
+    Non-redirect URLs pass through unchanged. Any network or timeout
+    error falls back to the original URL so the search flow is never broken.
+
+    Args:
+        client: A shared AsyncClient configured with follow_redirects=True.
+        url: The candidate URL from Gemini grounding metadata.
+
+    Returns:
+        The resolved destination URL, or the original URL on any failure.
+    """
+    if _VERTEX_REDIRECT_PREFIX not in url:
+        return url
+    try:
+        response = await client.head(url, timeout=3.0)
+        resolved = str(response.url)
+        if _VERTEX_REDIRECT_PREFIX in resolved:
+            return ""
+        return resolved
+    except httpx.HTTPError:
+        return ""
+
+
+async def _resolve_grounding_urls(urls: list[str]) -> list[str]:
+    """Resolve all grounding URLs in parallel, following Vertex AI redirects.
+
+    Args:
+        urls: Candidate URLs from Gemini grounding metadata.
+
+    Returns:
+        Resolved URLs in the same order as the input.
+    """
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        tasks = [_resolve_url(client, url) for url in urls]
+        return list(await asyncio.gather(*tasks))
 
 
 def _parse_gemini_response(text: str) -> dict:
@@ -50,6 +108,7 @@ def _parse_gemini_response(text: str) -> dict:
     if not match:
         raise json.JSONDecodeError("No JSON object found", text, 0)
     return json.loads(match.group())
+
 
 
 class AiSearchServices:
@@ -93,21 +152,19 @@ class AiSearchServices:
                     role="user", parts=[genai.types.Part(text=request.query_text)]
                 )
             )
+            max_sources = "3" if request.search_mode == "instant" else "10"
             response = await asyncio.to_thread(
                 client.models.generate_content,
                 model="gemini-2.5-flash",
                 contents=contents,
                 config=genai.types.GenerateContentConfig(
-                    system_instruction=_GEMINI_SYSTEM_INSTRUCTION,
+                    system_instruction=_build_system_instruction(max_sources),
                     tools=[genai.types.Tool(google_search=genai.types.GoogleSearch())],
                 ),
             )
             data = _parse_gemini_response(response.text or "")
             summary = data["summary"]
-            raw_sources = [
-                s for s in data["sources"]
-                if "vertexaisearch.cloud.google.com" not in s.get("url", "")
-            ]
+            raw_sources = await _build_raw_sources(data.get("sources", []))
         except (json.JSONDecodeError, KeyError) as exc:
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,
@@ -118,7 +175,7 @@ class AiSearchServices:
             if "UNAVAILABLE" in exc_str or "503" in exc_str:
                 raise HTTPException(
                     status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="The AI service is temporarily unavailable. Please try again in a moment.",
+                    detail="The AI service is temporarily busy. Please try again in a moment.",
                 ) from exc
             if "RESOURCE_EXHAUSTED" in exc_str or "429" in exc_str:
                 raise HTTPException(

--- a/server/tests/unit/ai_search/test_ai_search_services.py
+++ b/server/tests/unit/ai_search/test_ai_search_services.py
@@ -101,7 +101,7 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
-        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+        expect(ai_search_module, times=1).resolve_grounding_urls(...).thenReturn(
             ["https://example.com/acl-guide"]
         )
         expect(repo, times=1).get_all_url_verifications().thenReturn({})
@@ -139,7 +139,7 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
-        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+        expect(ai_search_module, times=1).resolve_grounding_urls(...).thenReturn(
             ["https://example.com/acl-guide"]
         )
         expect(repo, times=1).get_all_url_verifications().thenReturn(flags)
@@ -173,7 +173,7 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
-        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+        expect(ai_search_module, times=1).resolve_grounding_urls(...).thenReturn(
             ["https://example.com/acl-guide"]
         )
         expect(repo, times=1).get_all_url_verifications().thenReturn(flags)
@@ -304,7 +304,7 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
-        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+        expect(ai_search_module, times=1).resolve_grounding_urls(...).thenReturn(
             [verified_url]
         )
         expect(repo, times=1).get_all_url_verifications().thenReturn(flags)
@@ -692,7 +692,7 @@ class SearchRedirectResolutionTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
-        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+        expect(ai_search_module, times=1).resolve_grounding_urls(...).thenReturn(
             [real_url]
         )
         expect(repo, times=1).get_all_url_verifications().thenReturn({})

--- a/server/tests/unit/ai_search/test_ai_search_services.py
+++ b/server/tests/unit/ai_search/test_ai_search_services.py
@@ -3,17 +3,23 @@ import datetime
 import json
 import unittest
 
+import httpx
 from fastapi import HTTPException
 from google import genai as genai_module
 from mockito import expect, mock
 
+import app.services.ai_search_services as ai_search_module
 from app.dal.ai_search_repository import AiSearchRepository, ContentData
 from app.models.ai_search.ai_search import (
     AiSearchRequest,
     SaveContentRequest,
     VerifyContentRequest,
 )
-from app.services.ai_search_services import AiSearchServices
+from app.services.ai_search_services import (
+    AiSearchServices,
+    _VERTEX_REDIRECT_PREFIX,
+    _resolve_url,
+)
 
 
 def _make_search_request(**overrides) -> AiSearchRequest:
@@ -53,7 +59,7 @@ def _make_verify_request(**overrides) -> VerifyContentRequest:
 
 
 def _mock_gemini_response(summary: str = "Test summary", sources: list | None = None):
-    """Return a mock Gemini response object with a pre-set text attribute."""
+    """Return a mock Gemini response with text including URLs in the JSON payload."""
     if sources is None:
         sources = [
             {
@@ -95,6 +101,9 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
+        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+            ["https://example.com/acl-guide"]
+        )
         expect(repo, times=1).get_all_url_verifications().thenReturn({})
 
         # ACT
@@ -130,6 +139,9 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
+        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+            ["https://example.com/acl-guide"]
+        )
         expect(repo, times=1).get_all_url_verifications().thenReturn(flags)
 
         # ACT
@@ -161,6 +173,9 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
+        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+            ["https://example.com/acl-guide"]
+        )
         expect(repo, times=1).get_all_url_verifications().thenReturn(flags)
 
         # ACT
@@ -192,6 +207,7 @@ class AiSearchServicesTest(unittest.TestCase):
         expect(mock_models, times=1).generate_content(...).thenRaise(
             RuntimeError("network error")
         )
+        # _resolve_grounding_urls is not reached when generate_content raises
 
         # ACT / ASSERT
         with self.assertRaises(HTTPException) as ctx:
@@ -220,6 +236,7 @@ class AiSearchServicesTest(unittest.TestCase):
         expect(mock_models, times=1).generate_content(...).thenRaise(
             RuntimeError("503 UNAVAILABLE. This model is currently experiencing high demand.")
         )
+        # _resolve_grounding_urls is not reached when generate_content raises
 
         # ACT / ASSERT
         with self.assertRaises(HTTPException) as ctx:
@@ -248,6 +265,7 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(bad_response)
+        # _resolve_grounding_urls is not reached when JSON parsing fails
 
         # ACT / ASSERT
         with self.assertRaises(HTTPException) as ctx:
@@ -286,6 +304,9 @@ class AiSearchServicesTest(unittest.TestCase):
         ).thenReturn(1)
         expect(genai_module, times=1).Client(...).thenReturn(mock_client)
         expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
+        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+            [verified_url]
+        )
         expect(repo, times=1).get_all_url_verifications().thenReturn(flags)
 
         # ACT
@@ -332,28 +353,6 @@ class AiSearchServicesTest(unittest.TestCase):
         self.assertEqual(len(result), 2)
         self.assertEqual(result[0].query_id, 2)
         self.assertEqual(result[1].query_text, "First query")
-
-    # ------------------------------------------------------------------ #
-    # delete_query                                                         #
-    # ------------------------------------------------------------------ #
-
-    def test_delete_query_calls_cascade(self) -> None:
-        """
-        Given a query_id of 1,
-        When delete_query is called,
-        Then repository.delete_query_cascade is called exactly once with that query_id.
-        """
-        # PREPARE
-        repo = mock(AiSearchRepository)
-        service = AiSearchServices(repository=repo)
-
-        # MOCK
-        expect(repo, times=1).delete_query_cascade(1).thenReturn(None)
-
-        # ACT
-        asyncio.run(service.delete_query(1))
-
-        # ASSERT — verified by expect(times=1)
 
     # ------------------------------------------------------------------ #
     # save_content                                                         #
@@ -438,28 +437,6 @@ class AiSearchServicesTest(unittest.TestCase):
         asyncio.run(service.save_content(request))
 
         # ASSERT — verified by expect(times=1); insert_saved_content not set up so not called
-
-    # ------------------------------------------------------------------ #
-    # unsave_content                                                       #
-    # ------------------------------------------------------------------ #
-
-    def test_unsave_content_delegates(self) -> None:
-        """
-        Given a saving_id of 7,
-        When unsave_content is called,
-        Then repository.delete_saved_content is called exactly once with 7.
-        """
-        # PREPARE
-        repo = mock(AiSearchRepository)
-        service = AiSearchServices(repository=repo)
-
-        # MOCK
-        expect(repo, times=1).delete_saved_content(7).thenReturn(None)
-
-        # ACT
-        asyncio.run(service.unsave_content(7))
-
-        # ASSERT — verified by expect(times=1)
 
     # ------------------------------------------------------------------ #
     # verify_content                                                       #
@@ -592,3 +569,137 @@ class AiSearchServicesTest(unittest.TestCase):
         with self.assertRaises(HTTPException) as ctx:
             asyncio.run(service.verify_content(request))
         self.assertEqual(ctx.exception.status_code, 403)
+
+
+class ResolveUrlTest(unittest.TestCase):
+
+    def test_non_redirect_url_passes_through(self) -> None:
+        """
+        Given a regular URL that does not contain the Vertex redirect prefix,
+        When _resolve_url is called,
+        Then the original URL is returned unchanged and client.head is never called.
+        """
+        # PREPARE
+        client = mock(httpx.AsyncClient)
+        url = "https://www.webmd.com/first-aid/rice-method-injuries"
+
+        # MOCK — head must not be called
+        expect(client, times=0).head(...)
+
+        # ACT
+        result = asyncio.run(_resolve_url(client, url))
+
+        # ASSERT
+        self.assertEqual(result, url)
+
+    def test_redirect_url_is_resolved_to_final_destination(self) -> None:
+        """
+        Given a Vertex AI redirect URL,
+        When _resolve_url is called,
+        Then client.head is called with that URL and the str of response.url is returned.
+        """
+        # PREPARE
+        client = mock(httpx.AsyncClient)
+        redirect_url = f"https://{_VERTEX_REDIRECT_PREFIX}SOMETOKEN=="
+        final_url = "https://real.example.com/page"
+        mock_response = mock()
+        mock_response.url = httpx.URL(final_url)
+
+        # MOCK
+        expect(client, times=1).head(redirect_url, timeout=3.0).thenReturn(mock_response)
+
+        # ACT
+        result = asyncio.run(_resolve_url(client, redirect_url))
+
+        # ASSERT
+        self.assertEqual(result, final_url)
+
+    def test_network_error_returns_empty_string(self) -> None:
+        """
+        Given a Vertex AI redirect URL and client.head raises httpx.ConnectError,
+        When _resolve_url is called,
+        Then an empty string is returned so the source is discarded.
+        """
+        # PREPARE
+        client = mock(httpx.AsyncClient)
+        redirect_url = f"https://{_VERTEX_REDIRECT_PREFIX}SOMETOKEN=="
+
+        # MOCK
+        expect(client, times=1).head(redirect_url, timeout=3.0).thenRaise(
+            httpx.ConnectError("connection refused")
+        )
+
+        # ACT
+        result = asyncio.run(_resolve_url(client, redirect_url))
+
+        # ASSERT
+        self.assertEqual(result, "")
+
+    def test_timeout_returns_empty_string(self) -> None:
+        """
+        Given a Vertex AI redirect URL and client.head raises httpx.TimeoutException,
+        When _resolve_url is called,
+        Then an empty string is returned so the source is discarded.
+        """
+        # PREPARE
+        client = mock(httpx.AsyncClient)
+        redirect_url = f"https://{_VERTEX_REDIRECT_PREFIX}SOMETOKEN=="
+
+        # MOCK
+        expect(client, times=1).head(redirect_url, timeout=3.0).thenRaise(
+            httpx.TimeoutException("timed out")
+        )
+
+        # ACT
+        result = asyncio.run(_resolve_url(client, redirect_url))
+
+        # ASSERT
+        self.assertEqual(result, "")
+
+
+class SearchRedirectResolutionTest(unittest.TestCase):
+
+    def test_search_replaces_redirect_url_in_source_card(self) -> None:
+        """
+        Given Gemini grounding returns a Vertex AI redirect URL for one source,
+        And _resolve_grounding_urls resolves it to a real destination URL,
+        When search is called,
+        Then the returned SourceCard.url is the resolved destination URL.
+        """
+        # PREPARE
+        redirect_url = f"https://{_VERTEX_REDIRECT_PREFIX}EXPIRING_TOKEN=="
+        real_url = "https://www.physio-pedia.com/ACL_Reconstruction"
+        repo = mock(AiSearchRepository)
+        service = AiSearchServices(repository=repo)
+        request = _make_search_request()
+        mock_client = mock()
+        mock_models = mock()
+        mock_client.models = mock_models
+        gemini_response = _mock_gemini_response(
+            sources=[
+                {
+                    "title": "ACL Reconstruction Guide",
+                    "url": redirect_url,
+                    "description": "Comprehensive guide to ACL reconstruction.",
+                    "content_type": "Article",
+                }
+            ]
+        )
+
+        # MOCK
+        expect(repo, times=1).insert_query(
+            request.query_text, request.user_id, request.user_role
+        ).thenReturn(1)
+        expect(genai_module, times=1).Client(...).thenReturn(mock_client)
+        expect(mock_models, times=1).generate_content(...).thenReturn(gemini_response)
+        expect(ai_search_module, times=1)._resolve_grounding_urls(...).thenReturn(
+            [real_url]
+        )
+        expect(repo, times=1).get_all_url_verifications().thenReturn({})
+
+        # ACT
+        result = asyncio.run(service.search(request))
+
+        # ASSERT
+        self.assertEqual(len(result.sources), 1)
+        self.assertEqual(result.sources[0].url, real_url)


### PR DESCRIPTION
…cation

- Add "instant" vs "thinking" search modes with Jotai persistence
- Pass conversation history to Gemini for multi-turn context
- Resolve Vertex AI redirect URLs in parallel with timeout handling
- Add professional verification counts per source card
- Role-based 403 guard on verify endpoint (professionals only)
- New dropdown-menu UI primitive (Radix) for mode toggle in FollowUpBar
- SavedContentPage filter by verified/unverified with unsave/verify mutations
- ProfilePage role-aware back navigation and conditional activity card